### PR TITLE
Add treemap, streamgraph, and venn chart support

### DIFF
--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -248,7 +248,8 @@ export const useEditorStore = create<EditorStore>()(
           regressionOrder: 2,
           startDateField: '',
           endDateField: '',
-          taskNameField: ''
+          taskNameField: '',
+          vennFields: []
         }
       },
       updateChartSettings: (settings) => set((state) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,7 +94,20 @@ export interface SqlNotebookSnapshotMeta {
 
 // チャート設定に関する型定義
 export interface ChartSettings {
-  type: 'bar' | 'line' | 'pie' | 'scatter' | 'stacked-bar' | 'regression' | 'histogram' | 'bubble' | 'sunburst' | 'gantt';
+  type:
+    | 'bar'
+    | 'line'
+    | 'pie'
+    | 'scatter'
+    | 'stacked-bar'
+    | 'regression'
+    | 'histogram'
+    | 'bubble'
+    | 'sunburst'
+    | 'gantt'
+    | 'treemap'
+    | 'streamgraph'
+    | 'venn';
   xAxis: string;
   yAxis: string;
   aggregation: 'sum' | 'avg' | 'count' | 'min' | 'max' | 'none';
@@ -107,6 +120,7 @@ export interface ChartSettings {
     startDateField?: string;
     endDateField?: string;
     taskNameField?: string;
+    vennFields?: string[];
   }
 }
 


### PR DESCRIPTION
## Summary
- extend single-file and multi-file analysis settings to expose treemap, streamgraph, and venn chart types with appropriate field pickers and option resets
- enhance chart generation to validate venn inputs, surface prepareChartData metadata errors, and render plotly-based layouts for the new visualizations across both analysis views
- update shared chart utilities, store defaults, and types so treemap, streamgraph, and venn data preparations are available with persisted venn field selections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d261c6ed88832f8ec7ac6b9024fe21