### PR TITLE
feat: add mermaid designer with react flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-json-view-lite": "^2.4.2",
         "react-markdown": "^10.1.0",
         "react-plotly.js": "^2.6.0",
+        "reactflow": "^11.11.4",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "turndown": "^7.2.0",
@@ -2510,6 +2511,276 @@
       "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
       "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
       "license": "MIT"
+    },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/background/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -5666,6 +5937,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
+      "license": "MIT"
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
     "node_modules/cli-truncate": {
@@ -14283,6 +14560,24 @@
         "react": ">0.13.0"
       }
     },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read-config-file": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
@@ -16578,6 +16873,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-json-view-lite": "^2.4.2",
     "react-markdown": "^10.1.0",
     "react-plotly.js": "^2.6.0",
+    "reactflow": "^11.11.4",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "turndown": "^7.2.0",

--- a/src/components/mermaid/MermaidDesigner.tsx
+++ b/src/components/mermaid/MermaidDesigner.tsx
@@ -1,0 +1,642 @@
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import ReactFlow, {
+  Background,
+  Connection,
+  Controls,
+  EdgeChange,
+  MiniMap,
+  NodeChange,
+  ReactFlowProvider,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  useReactFlow,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import {
+  IoAdd,
+  IoAlertCircleOutline,
+  IoCopy,
+  IoTrash,
+} from 'react-icons/io5';
+import { useEditorStore } from '@/store/editorStore';
+import {
+  diagramDefinitions,
+  diagramList,
+  type MermaidEdgeTemplate,
+  type MermaidFieldDefinition,
+  type MermaidNodeTemplate,
+} from '@/lib/mermaid/diagramDefinitions';
+import {
+  parseMermaidSource,
+} from '@/lib/mermaid/parser';
+import {
+  serializeMermaid,
+} from '@/lib/mermaid/serializer';
+import type {
+  MermaidDiagramConfig,
+  MermaidDiagramType,
+  MermaidEdge,
+  MermaidGraphModel,
+  MermaidNode,
+} from '@/lib/mermaid/types';
+import MermaidPreview from '@/components/preview/MermaidPreview';
+
+interface MermaidDesignerProps {
+  tabId: string;
+  fileName: string;
+  content: string;
+}
+
+interface InspectorState {
+  type: 'node' | 'edge';
+  id: string;
+}
+
+const getDefaultEdgeVariant = (type: MermaidDiagramType): string => {
+  const definition = diagramDefinitions[type];
+  return definition.edgeTemplates[0]?.variant || 'arrow';
+};
+
+const toBooleanString = (value: boolean): string => (value ? 'true' : 'false');
+
+const parseBoolean = (value: string | undefined): boolean => value === 'true';
+
+const useTabActions = () => {
+  const updateTab = useEditorStore((state) => state.updateTab);
+  const getTab = useEditorStore((state) => state.getTab);
+  return { updateTab, getTab };
+};
+
+const buildModel = (
+  type: MermaidDiagramType,
+  config: MermaidDiagramConfig,
+  nodes: MermaidNode[],
+  edges: MermaidEdge[],
+): MermaidGraphModel => ({
+  type,
+  config,
+  nodes,
+  edges,
+  warnings: [],
+});
+
+const FieldInput: React.FC<{
+  field: MermaidFieldDefinition;
+  value: string;
+  onChange: (value: string) => void;
+}> = ({ field, value, onChange }) => {
+  switch (field.type) {
+    case 'textarea':
+      return (
+        <textarea
+          className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+          rows={4}
+          value={value}
+          placeholder={field.placeholder}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    case 'select':
+      return (
+        <select
+          className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        >
+          {field.options?.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      );
+    case 'boolean':
+      return (
+        <label className="flex items-center space-x-2 text-sm">
+          <input
+            type="checkbox"
+            checked={parseBoolean(value)}
+            onChange={(event) => onChange(toBooleanString(event.target.checked))}
+          />
+          <span>{field.placeholder ?? '有効化'}</span>
+        </label>
+      );
+    case 'number':
+      return (
+        <input
+          type="number"
+          className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+          value={value}
+          placeholder={field.placeholder}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    case 'date':
+      return (
+        <input
+          type="date"
+          className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    case 'text':
+    default:
+      return (
+        <input
+          type="text"
+          className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+          value={value}
+          placeholder={field.placeholder}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+  }
+};
+
+const MermaidDesignerInner: React.FC<MermaidDesignerProps> = ({ tabId, fileName, content }) => {
+  const { updateTab, getTab } = useTabActions();
+  const [diagramType, setDiagramType] = useState<MermaidDiagramType>('flowchart');
+  const [config, setConfig] = useState<MermaidDiagramConfig>(diagramDefinitions.flowchart.defaultConfig);
+  const [nodes, setNodes] = useState<MermaidNode[]>([]);
+  const [edges, setEdges] = useState<MermaidEdge[]>([]);
+  const [generatedCode, setGeneratedCode] = useState<string>('');
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [inspector, setInspector] = useState<InspectorState | null>(null);
+  const [isPaletteCollapsed, setIsPaletteCollapsed] = useState<boolean>(false);
+  const lastSerializedRef = useRef<string>('');
+  const isHydrating = useRef<boolean>(false);
+  const hasInitialized = useRef<boolean>(false);
+  const reactFlow = useReactFlow();
+
+  const nodeTemplates = useMemo<MermaidNodeTemplate[]>(
+    () => diagramDefinitions[diagramType].nodeTemplates,
+    [diagramType],
+  );
+  const edgeTemplates = useMemo<MermaidEdgeTemplate[]>(
+    () => diagramDefinitions[diagramType].edgeTemplates,
+    [diagramType],
+  );
+  const configFields = useMemo<MermaidFieldDefinition[]>(
+    () => diagramDefinitions[diagramType].configFields ?? [],
+    [diagramType],
+  );
+
+  const refreshGeneratedCode = useCallback(() => {
+    const model = buildModel(diagramType, config, nodes, edges);
+    const { code, warnings: serializationWarnings } = serializeMermaid(model);
+    setGeneratedCode(code);
+    setWarnings(serializationWarnings);
+    lastSerializedRef.current = code;
+    const tab = getTab(tabId);
+    if (tab) {
+      const isDirty = tab.originalContent !== code;
+      if (tab.content !== code || tab.isDirty !== isDirty) {
+        updateTab(tabId, { content: code, isDirty });
+      }
+    }
+  }, [diagramType, config, nodes, edges, getTab, tabId, updateTab]);
+
+  useEffect(() => {
+    if (content === lastSerializedRef.current) {
+      return;
+    }
+    isHydrating.current = true;
+    const parsed = parseMermaidSource(content);
+    setDiagramType(parsed.type);
+    setConfig(parsed.config);
+    setNodes(parsed.nodes);
+    setEdges(parsed.edges.map((edge) => ({ ...edge, label: edge.data.label })));
+    setWarnings(parsed.warnings);
+    const { code } = serializeMermaid(parsed);
+    setGeneratedCode(code);
+    lastSerializedRef.current = code;
+    setInspector(null);
+    hasInitialized.current = true;
+    requestAnimationFrame(() => {
+      isHydrating.current = false;
+      reactFlow.fitView({ padding: 0.2, duration: 300 });
+    });
+  }, [content, reactFlow]);
+
+  useEffect(() => {
+    if (!hasInitialized.current) return;
+    if (isHydrating.current) return;
+    refreshGeneratedCode();
+  }, [diagramType, config, nodes, edges, refreshGeneratedCode]);
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes((current) => applyNodeChanges(changes, current));
+  }, []);
+
+  const handleEdgesChange = useCallback((changes: EdgeChange[]) => {
+    setEdges((current) => applyEdgeChanges(changes, current));
+  }, []);
+
+  const handleConnect = useCallback((connection: Connection) => {
+    if (!connection.source || !connection.target) return;
+    const template = edgeTemplates[0];
+    const newEdge: MermaidEdge = {
+      id: `edge_${Date.now()}`,
+      source: connection.source,
+      target: connection.target,
+      data: {
+        diagramType,
+        variant: template?.variant ?? getDefaultEdgeVariant(diagramType),
+        label: template?.defaultLabel,
+        metadata: template?.defaultMetadata ? { ...template.defaultMetadata } : {},
+      },
+      label: template?.defaultLabel,
+    };
+    setEdges((current) => addEdge(newEdge, current));
+  }, [diagramType, edgeTemplates]);
+
+  const handleSelectionChange = useCallback((params: { nodes: MermaidNode[]; edges: MermaidEdge[] }) => {
+    if (params.nodes.length > 0) {
+      setInspector({ type: 'node', id: params.nodes[0].id });
+    } else if (params.edges.length > 0) {
+      setInspector({ type: 'edge', id: params.edges[0].id });
+    } else {
+      setInspector(null);
+    }
+  }, []);
+
+  const handleAddNode = useCallback((template: MermaidNodeTemplate) => {
+    const definition = diagramDefinitions[diagramType];
+    const id = definition.createNodeId ? definition.createNodeId() : `node_${Date.now()}`;
+    const newNode: MermaidNode = {
+      id,
+      type: 'default',
+      position: {
+        x: (nodes.length % 4) * 200 + 50,
+        y: Math.floor(nodes.length / 4) * 150 + 40,
+      },
+      data: {
+        diagramType,
+        variant: template.variant,
+        label: template.defaultLabel,
+        metadata: template.defaultMetadata ? { ...template.defaultMetadata } : {},
+      },
+    };
+    setNodes((current) => [...current, newNode]);
+    setInspector({ type: 'node', id });
+  }, [diagramType, nodes.length]);
+
+  const updateNode = useCallback((nodeId: string, updater: (node: MermaidNode) => MermaidNode) => {
+    setNodes((current) => current.map((node) => (node.id === nodeId ? updater(node) : node)));
+  }, []);
+
+  const updateEdge = useCallback((edgeId: string, updater: (edge: MermaidEdge) => MermaidEdge) => {
+    setEdges((current) => current.map((edge) => (edge.id === edgeId ? updater(edge) : edge)));
+  }, []);
+
+  const handleDiagramTypeChange = useCallback((nextType: MermaidDiagramType) => {
+    if (nextType === diagramType) return;
+    let allowSwitch = true;
+    if ((nodes.length > 0 || edges.length > 0) && typeof window !== 'undefined') {
+      allowSwitch = window.confirm('図の種類を変更すると現在の要素はクリアされます。続行しますか？');
+    }
+    if (!allowSwitch) return;
+    const definition = diagramDefinitions[nextType];
+    setDiagramType(nextType);
+    setConfig(definition.defaultConfig);
+    setNodes([]);
+    setEdges([]);
+    setWarnings([]);
+    setInspector(null);
+  }, [diagramType, nodes.length, edges.length]);
+
+  const handleDeleteSelection = useCallback(() => {
+    if (!inspector) return;
+    if (inspector.type === 'node') {
+      setNodes((current) => current.filter((node) => node.id !== inspector.id));
+      setEdges((current) => current.filter((edge) => edge.source !== inspector.id && edge.target !== inspector.id));
+    } else {
+      setEdges((current) => current.filter((edge) => edge.id !== inspector.id));
+    }
+    setInspector(null);
+  }, [inspector]);
+
+  const handleCopyCode = useCallback(() => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(generatedCode).catch(() => {
+        // ignore copy failure
+      });
+    }
+  }, [generatedCode]);
+
+  const paletteClasses = isPaletteCollapsed ? 'w-12' : 'w-64';
+
+  const selectedNode = useMemo(() => nodes.find((node) => inspector?.type === 'node' && node.id === inspector.id), [inspector, nodes]);
+  const selectedEdge = useMemo(() => edges.find((edge) => inspector?.type === 'edge' && edge.id === inspector.id), [inspector, edges]);
+
+  const selectedNodeTemplate = useMemo(() => {
+    if (!selectedNode) return undefined;
+    return nodeTemplates.find((template) => template.variant === selectedNode.data.variant);
+  }, [selectedNode, nodeTemplates]);
+
+  const selectedEdgeTemplate = useMemo(() => {
+    if (!selectedEdge) return undefined;
+    return edgeTemplates.find((template) => template.variant === selectedEdge.data.variant);
+  }, [selectedEdge, edgeTemplates]);
+
+  const renderNodeInspector = () => {
+    if (!selectedNode) {
+      return <p className="text-sm text-gray-500">ノードを選択すると詳細を編集できます。</p>;
+    }
+    return (
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500">ノード種別</label>
+          <select
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+            value={selectedNode.data.variant}
+            onChange={(event) => {
+              const nextVariant = event.target.value;
+              const template = nodeTemplates.find((item) => item.variant === nextVariant);
+              updateNode(selectedNode.id, (node) => ({
+                ...node,
+                data: {
+                  ...node.data,
+                  variant: nextVariant,
+                  label: template ? template.defaultLabel : node.data.label,
+                  metadata: template?.defaultMetadata ? { ...template.defaultMetadata } : {},
+                },
+              }));
+            }}
+          >
+            {nodeTemplates.map((template) => (
+              <option key={template.variant} value={template.variant}>
+                {template.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500">ラベル</label>
+          <input
+            type="text"
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+            value={selectedNode.data.label}
+            onChange={(event) => {
+              const value = event.target.value;
+              updateNode(selectedNode.id, (node) => ({
+                ...node,
+                data: { ...node.data, label: value },
+              }));
+            }}
+          />
+        </div>
+        {selectedNodeTemplate?.fields?.map((field) => {
+          const value = selectedNode.data.metadata?.[field.key] ?? '';
+          return (
+            <div key={field.key}>
+              <label className="block text-xs text-gray-500">{field.label}</label>
+              <FieldInput
+                field={field}
+                value={value}
+                onChange={(newValue) => {
+                  updateNode(selectedNode.id, (node) => ({
+                    ...node,
+                    data: {
+                      ...node.data,
+                      metadata: { ...node.data.metadata, [field.key]: newValue },
+                    },
+                  }));
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderEdgeInspector = () => {
+    if (!selectedEdge) {
+      return <p className="text-sm text-gray-500">エッジを選択すると詳細を編集できます。</p>;
+    }
+    return (
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500">エッジ種別</label>
+          <select
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+            value={selectedEdge.data.variant}
+            onChange={(event) => {
+              const nextVariant = event.target.value;
+              const template = edgeTemplates.find((item) => item.variant === nextVariant);
+              updateEdge(selectedEdge.id, (edge) => ({
+                ...edge,
+                data: {
+                  ...edge.data,
+                  variant: nextVariant,
+                  label: template?.defaultLabel,
+                  metadata: template?.defaultMetadata ? { ...template.defaultMetadata } : {},
+                },
+                label: template?.defaultLabel,
+              }));
+            }}
+          >
+            {edgeTemplates.map((template) => (
+              <option key={template.variant} value={template.variant}>
+                {template.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        {selectedEdgeTemplate?.fields?.map((field) => {
+          const value = selectedEdge.data.metadata?.[field.key] ?? selectedEdge.data.label ?? '';
+          return (
+            <div key={field.key}>
+              <label className="block text-xs text-gray-500">{field.label}</label>
+              <FieldInput
+                field={field}
+                value={value}
+                onChange={(newValue) => {
+                  updateEdge(selectedEdge.id, (edge) => ({
+                    ...edge,
+                    data: {
+                      ...edge.data,
+                      label: field.key === 'label' ? newValue : edge.data.label,
+                      metadata: { ...edge.data.metadata, [field.key]: newValue },
+                    },
+                    label: field.key === 'label' ? newValue : edge.label,
+                  }));
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full flex">
+      <aside className={`border-r border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 transition-all duration-200 ${paletteClasses}`}>
+        <div className="p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-gray-500">図の種類</label>
+            <button
+              type="button"
+              className="text-xs text-blue-600"
+              onClick={() => setIsPaletteCollapsed((prev) => !prev)}
+            >
+              {isPaletteCollapsed ? '展開' : '折りたたむ'}
+            </button>
+          </div>
+          {!isPaletteCollapsed && (
+            <select
+              className="w-full border border-gray-300 dark:border-gray-700 rounded p-1 text-sm"
+              value={diagramType}
+              onChange={(event) => handleDiagramTypeChange(event.target.value as MermaidDiagramType)}
+            >
+              {diagramList.map((item) => (
+                <option key={item.type} value={item.type}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {!isPaletteCollapsed && (
+            <div>
+              <p className="text-xs text-gray-500 mb-2">ノードを追加</p>
+              <div className="space-y-2">
+                {nodeTemplates.map((template) => (
+                  <button
+                    key={template.variant}
+                    type="button"
+                    className="w-full flex items-center justify-between px-2 py-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                    onClick={() => handleAddNode(template)}
+                  >
+                    <span>{template.label}</span>
+                    <IoAdd />
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {!isPaletteCollapsed && edgeTemplates.length > 0 && (
+            <div>
+              <p className="text-xs text-gray-500 mb-2">接続種別</p>
+              <ul className="space-y-1 text-xs text-gray-600 dark:text-gray-300">
+                {edgeTemplates.map((template) => (
+                  <li key={template.variant}>{template.label}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {!isPaletteCollapsed && configFields.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs text-gray-500">図の設定</p>
+              {configFields.map((field) => {
+                const value = (config as any)[field.key]?.toString?.() ?? '';
+                return (
+                  <div key={field.key}>
+                    <label className="block text-xs text-gray-500">{field.label}</label>
+                    <FieldInput
+                      field={field}
+                      value={value}
+                      onChange={(newValue) => {
+                        setConfig((current) => ({
+                          ...(current as any),
+                          [field.key]: field.type === 'boolean' ? newValue === 'true' : field.type === 'number' ? Number(newValue) : newValue,
+                        }));
+                      }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </aside>
+      <main className="flex-1 flex flex-col">
+        <div className="flex-1">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={handleNodesChange}
+            onEdgesChange={handleEdgesChange}
+            onConnect={handleConnect}
+            onSelectionChange={handleSelectionChange}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+          >
+            <Background />
+            <MiniMap />
+            <Controls />
+          </ReactFlow>
+        </div>
+      </main>
+      <aside className="w-96 border-l border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex flex-col">
+        <div className="p-4 space-y-3 overflow-y-auto flex-1">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold">プロパティ</h3>
+            <button
+              type="button"
+              className="flex items-center text-xs text-red-600"
+              onClick={handleDeleteSelection}
+              disabled={!inspector}
+            >
+              <IoTrash className="mr-1" /> 削除
+            </button>
+          </div>
+          {inspector?.type === 'node' ? renderNodeInspector() : inspector?.type === 'edge' ? renderEdgeInspector() : (
+            <p className="text-sm text-gray-500">ノードまたはエッジを選択してください。</p>
+          )}
+          {warnings.length > 0 && (
+            <div className="bg-yellow-50 border border-yellow-300 text-yellow-700 rounded p-2 text-xs space-y-1">
+              <div className="flex items-center font-semibold">
+                <IoAlertCircleOutline className="mr-1" /> Mermaid変換警告
+              </div>
+              <ul className="list-disc list-inside space-y-1">
+                {warnings.map((warning, index) => (
+                  <li key={`warning-${index}`}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-sm font-semibold">Mermaid記法</h3>
+              <button
+                type="button"
+                className="flex items-center text-xs text-blue-600"
+                onClick={handleCopyCode}
+              >
+                <IoCopy className="mr-1" /> コピー
+              </button>
+            </div>
+            <textarea
+              className="w-full h-40 border border-gray-300 dark:border-gray-700 rounded p-2 text-xs font-mono bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-100"
+              value={generatedCode}
+              readOnly
+            />
+          </div>
+          <div className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
+            <MermaidPreview content={generatedCode} fileName={fileName} />
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+const MermaidDesigner: React.FC<MermaidDesignerProps> = (props) => (
+  <ReactFlowProvider>
+    <MermaidDesignerInner {...props} />
+  </ReactFlowProvider>
+);
+
+export default MermaidDesigner;

--- a/src/components/preview/DataPreview.tsx
+++ b/src/components/preview/DataPreview.tsx
@@ -29,7 +29,7 @@ import { formatData } from '@/lib/dataFormatUtils';
 import DataTable from './DataTable';
 import EditableDataTable from './EditableDataTable';
 import ObjectViewer from './ObjectViewer';
-import MermaidPreview from './MermaidPreview';
+import MermaidDesigner from '@/components/mermaid/MermaidDesigner';
 import IpynbPreview from './IpynbPreview';
 import PdfPreview from './PdfPreview';
 import ExcelPreview from './ExcelPreview';
@@ -870,7 +870,11 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
         <div className="flex-1 overflow-auto">
           {/* Mermaid図式の場合 */}
           {type === 'mermaid' && (
-            <MermaidPreview content={content} fileName={tabs.get(tabId)?.name || 'mermaid-diagram.mmd'} />
+            <MermaidDesigner
+              tabId={tabId}
+              fileName={tabs.get(tabId)?.name || 'mermaid-diagram.mmd'}
+              content={content}
+            />
           )}
           {/* Jupyter Notebookプレビュー */}
           {type === 'ipynb' && parsedData && (

--- a/src/lib/mermaid/diagramDefinitions.ts
+++ b/src/lib/mermaid/diagramDefinitions.ts
@@ -1,0 +1,419 @@
+import type { MermaidDiagramConfig, MermaidDiagramType } from './types';
+
+/** フォームフィールドの種別 */
+export type MermaidFieldType = 'text' | 'textarea' | 'select' | 'number' | 'boolean' | 'date';
+
+/** ノード・エッジ・設定で共通のフィールド定義 */
+export interface MermaidFieldDefinition {
+  key: string;
+  label: string;
+  type: MermaidFieldType;
+  description?: string;
+  placeholder?: string;
+  options?: { value: string; label: string }[];
+}
+
+/** ノードのテンプレート定義 */
+export interface MermaidNodeTemplate {
+  variant: string;
+  label: string;
+  description?: string;
+  defaultLabel: string;
+  defaultMetadata?: Record<string, string>;
+  fields?: MermaidFieldDefinition[];
+}
+
+/** エッジのテンプレート定義 */
+export interface MermaidEdgeTemplate {
+  variant: string;
+  label: string;
+  description?: string;
+  defaultLabel?: string;
+  defaultMetadata?: Record<string, string>;
+  fields?: MermaidFieldDefinition[];
+}
+
+/** 図種別ごとの定義 */
+export interface MermaidDiagramDefinition {
+  type: MermaidDiagramType;
+  label: string;
+  description: string;
+  nodeTemplates: MermaidNodeTemplate[];
+  edgeTemplates: MermaidEdgeTemplate[];
+  defaultConfig: MermaidDiagramConfig;
+  configFields?: MermaidFieldDefinition[];
+  supportsEdges: boolean;
+  /** ノード追加時にユニークIDを生成するヘルパー */
+  createNodeId?: () => string;
+}
+
+let idCounter = 0;
+const createId = () => {
+  idCounter += 1;
+  return idCounter.toString(36).padStart(4, '0');
+};
+
+/** 図種別ごとのテンプレート定義 */
+export const diagramDefinitions: Record<MermaidDiagramType, MermaidDiagramDefinition> = {
+  flowchart: {
+    type: 'flowchart',
+    label: 'フローチャート',
+    description: '処理の流れを表現する基本的なフローチャート',
+    nodeTemplates: [
+      {
+        variant: 'startEnd',
+        label: '開始/終了',
+        description: '開始・終了を表す端点',
+        defaultLabel: 'Start',
+      },
+      {
+        variant: 'process',
+        label: '処理',
+        description: '通常の処理ステップ',
+        defaultLabel: 'Process',
+      },
+      {
+        variant: 'decision',
+        label: '分岐',
+        description: '条件分岐',
+        defaultLabel: 'Decision',
+      },
+      {
+        variant: 'inputOutput',
+        label: '入出力',
+        description: '入力または出力',
+        defaultLabel: 'I/O',
+      },
+      {
+        variant: 'subroutine',
+        label: 'サブルーチン',
+        description: 'サブルーチン呼び出し',
+        defaultLabel: 'Subroutine',
+      },
+    ],
+    edgeTemplates: [
+      {
+        variant: 'arrow',
+        label: '通常の矢印',
+        defaultMetadata: {},
+        fields: [
+          { key: 'label', label: 'ラベル', type: 'text', placeholder: 'Yes/No など' },
+        ],
+      },
+      {
+        variant: 'dashed',
+        label: '破線矢印',
+        description: '補助的な流れ',
+        fields: [
+          { key: 'label', label: 'ラベル', type: 'text', placeholder: '補足説明' },
+        ],
+      },
+      {
+        variant: 'thick',
+        label: '強調矢印',
+        description: '重要な流れを強調',
+        fields: [
+          { key: 'label', label: 'ラベル', type: 'text' },
+        ],
+      },
+    ],
+    defaultConfig: { type: 'flowchart', orientation: 'TD' },
+    configFields: [
+      {
+        key: 'orientation',
+        label: 'レイアウト方向',
+        type: 'select',
+        options: [
+          { value: 'TD', label: '上 → 下 (TD)' },
+          { value: 'TB', label: '上 → 下 (TB)' },
+          { value: 'BT', label: '下 → 上 (BT)' },
+          { value: 'LR', label: '左 → 右 (LR)' },
+          { value: 'RL', label: '右 → 左 (RL)' },
+        ],
+      },
+    ],
+    supportsEdges: true,
+    createNodeId: () => `node_${createId()}`,
+  },
+  sequence: {
+    type: 'sequence',
+    label: 'シーケンス図',
+    description: 'オブジェクト間のメッセージの時系列を表現',
+    nodeTemplates: [
+      {
+        variant: 'participant',
+        label: '参加者',
+        defaultLabel: 'Participant',
+        fields: [
+          { key: 'alias', label: '識別子', type: 'text', placeholder: '内部ID (省略可)' },
+        ],
+      },
+      {
+        variant: 'actor',
+        label: 'アクター',
+        defaultLabel: 'Actor',
+        fields: [
+          { key: 'alias', label: '識別子', type: 'text', placeholder: '内部ID (省略可)' },
+        ],
+      },
+      {
+        variant: 'boundary',
+        label: 'バウンダリ',
+        defaultLabel: 'Boundary',
+        fields: [
+          { key: 'alias', label: '識別子', type: 'text' },
+        ],
+      },
+      {
+        variant: 'control',
+        label: 'コントロール',
+        defaultLabel: 'Control',
+        fields: [
+          { key: 'alias', label: '識別子', type: 'text' },
+        ],
+      },
+      {
+        variant: 'database',
+        label: 'データベース',
+        defaultLabel: 'DB',
+        fields: [
+          { key: 'alias', label: '識別子', type: 'text' },
+        ],
+      },
+    ],
+    edgeTemplates: [
+      {
+        variant: 'solid',
+        label: '同期メッセージ',
+        defaultLabel: 'Message',
+        fields: [
+          { key: 'label', label: 'メッセージ', type: 'text', placeholder: 'メッセージ内容' },
+        ],
+      },
+      {
+        variant: 'dashed',
+        label: '非同期メッセージ',
+        defaultLabel: 'Async',
+        fields: [
+          { key: 'label', label: 'メッセージ', type: 'text' },
+        ],
+      },
+      {
+        variant: 'open',
+        label: 'オープン矢印',
+        defaultLabel: 'Signal',
+        fields: [
+          { key: 'label', label: 'メッセージ', type: 'text' },
+        ],
+      },
+    ],
+    defaultConfig: { type: 'sequence', autoNumber: false },
+    configFields: [
+      {
+        key: 'autoNumber',
+        label: '自動番号',
+        type: 'boolean',
+        description: 'メッセージに自動連番を付与',
+      },
+    ],
+    supportsEdges: true,
+    createNodeId: () => `actor_${createId()}`,
+  },
+  class: {
+    type: 'class',
+    label: 'クラス図',
+    description: 'クラスとその関係を表現',
+    nodeTemplates: [
+      {
+        variant: 'class',
+        label: 'クラス',
+        defaultLabel: 'ClassName',
+        fields: [
+          { key: 'stereotype', label: 'ステレオタイプ', type: 'text', placeholder: '<<interface>> など' },
+          { key: 'members', label: '属性', type: 'textarea', placeholder: '属性1\n属性2' },
+          { key: 'methods', label: '操作', type: 'textarea', placeholder: '+ operation()' },
+        ],
+      },
+      {
+        variant: 'interface',
+        label: 'インターフェース',
+        defaultLabel: 'Interface',
+        defaultMetadata: { stereotype: '<<interface>>' },
+        fields: [
+          { key: 'members', label: '属性', type: 'textarea' },
+          { key: 'methods', label: '操作', type: 'textarea' },
+        ],
+      },
+      {
+        variant: 'abstract',
+        label: '抽象クラス',
+        defaultLabel: 'AbstractClass',
+        defaultMetadata: { stereotype: '<<abstract>>' },
+        fields: [
+          { key: 'members', label: '属性', type: 'textarea' },
+          { key: 'methods', label: '操作', type: 'textarea' },
+        ],
+      },
+    ],
+    edgeTemplates: [
+      { variant: 'inheritance', label: '継承 (<|--)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'composition', label: 'コンポジション (*--)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'aggregation', label: '集約 (o--)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'association', label: '関連 (--)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'dependency', label: '依存 (..>)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+    ],
+    defaultConfig: { type: 'class', direction: 'TB' },
+    configFields: [
+      {
+        key: 'direction',
+        label: '方向',
+        type: 'select',
+        options: [
+          { value: 'TB', label: '縦方向 (TB)' },
+          { value: 'LR', label: '横方向 (LR)' },
+        ],
+      },
+    ],
+    supportsEdges: true,
+    createNodeId: () => `class_${createId()}`,
+  },
+  state: {
+    type: 'state',
+    label: 'ステート図',
+    description: '状態遷移を表現',
+    nodeTemplates: [
+      {
+        variant: 'state',
+        label: '状態',
+        defaultLabel: 'State',
+      },
+      {
+        variant: 'start',
+        label: '開始',
+        defaultLabel: 'Start',
+      },
+      {
+        variant: 'end',
+        label: '終了',
+        defaultLabel: 'End',
+      },
+      {
+        variant: 'choice',
+        label: '分岐',
+        defaultLabel: 'Choice',
+      },
+    ],
+    edgeTemplates: [
+      {
+        variant: 'transition',
+        label: '遷移',
+        fields: [
+          { key: 'label', label: 'イベント/条件', type: 'text', placeholder: 'イベント / ガード [アクション]' },
+        ],
+      },
+    ],
+    defaultConfig: { type: 'state', direction: 'TB' },
+    configFields: [
+      {
+        key: 'direction',
+        label: '方向',
+        type: 'select',
+        options: [
+          { value: 'TB', label: '縦方向 (TB)' },
+          { value: 'LR', label: '横方向 (LR)' },
+        ],
+      },
+    ],
+    supportsEdges: true,
+    createNodeId: () => `state_${createId()}`,
+  },
+  er: {
+    type: 'er',
+    label: 'ER 図',
+    description: 'エンティティとリレーションシップを表現',
+    nodeTemplates: [
+      {
+        variant: 'entity',
+        label: 'エンティティ',
+        defaultLabel: 'Entity',
+        fields: [
+          { key: 'attributes', label: '属性', type: 'textarea', placeholder: 'id PK\nname' },
+        ],
+      },
+      {
+        variant: 'weakEntity',
+        label: '弱エンティティ',
+        defaultLabel: 'WeakEntity',
+        fields: [
+          { key: 'attributes', label: '属性', type: 'textarea' },
+        ],
+      },
+    ],
+    edgeTemplates: [
+      { variant: 'identifying', label: '識別 (||--||)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'nonIdentifying', label: '非識別 (||--o{)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'oneToMany', label: '1対多 (||--|{)', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+      { variant: 'manyToMany', label: '多対多 ({--})', fields: [{ key: 'label', label: '説明', type: 'text' }] },
+    ],
+    defaultConfig: { type: 'er' },
+    supportsEdges: true,
+    createNodeId: () => `entity_${createId()}`,
+  },
+  gantt: {
+    type: 'gantt',
+    label: 'ガントチャート',
+    description: 'スケジュール管理用ガントチャート',
+    nodeTemplates: [
+      {
+        variant: 'task',
+        label: 'タスク',
+        defaultLabel: 'Task',
+        defaultMetadata: { status: 'active', section: 'General' },
+        fields: [
+          { key: 'section', label: 'セクション', type: 'text', placeholder: 'カテゴリ名' },
+          { key: 'taskId', label: 'タスクID', type: 'text', placeholder: 'task_1' },
+          { key: 'start', label: '開始日', type: 'date' },
+          { key: 'end', label: '終了日', type: 'date' },
+          { key: 'duration', label: '期間 (例: 5d)', type: 'text' },
+          { key: 'dependsOn', label: '依存タスクID', type: 'text', placeholder: 'task_2' },
+          {
+            key: 'status',
+            label: '状態',
+            type: 'select',
+            options: [
+              { value: 'active', label: '進行中' },
+              { value: 'done', label: '完了' },
+              { value: 'crit', label: '重要' },
+              { value: 'milestone', label: 'マイルストーン' },
+            ],
+          },
+        ],
+      },
+      {
+        variant: 'milestone',
+        label: 'マイルストーン',
+        defaultLabel: 'Milestone',
+        defaultMetadata: { status: 'milestone', section: 'General' },
+        fields: [
+          { key: 'section', label: 'セクション', type: 'text' },
+          { key: 'taskId', label: 'タスクID', type: 'text' },
+          { key: 'start', label: '日付', type: 'date' },
+          { key: 'dependsOn', label: '依存タスクID', type: 'text' },
+        ],
+      },
+    ],
+    edgeTemplates: [],
+    defaultConfig: { type: 'gantt', dateFormat: 'YYYY-MM-DD', axisFormat: '%m/%d', title: 'Timeline' },
+    configFields: [
+      { key: 'title', label: 'タイトル', type: 'text' },
+      { key: 'dateFormat', label: '日付フォーマット', type: 'text', placeholder: 'YYYY-MM-DD' },
+      { key: 'axisFormat', label: '軸フォーマット', type: 'text', placeholder: '%m/%d' },
+    ],
+    supportsEdges: false,
+    createNodeId: () => `task_${createId()}`,
+  },
+};
+
+export const diagramList: { type: MermaidDiagramType; label: string }[] = Object.values(diagramDefinitions).map(
+  ({ type, label }) => ({ type, label })
+);

--- a/src/lib/mermaid/index.ts
+++ b/src/lib/mermaid/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './diagramDefinitions';
+export * from './parser';
+export * from './serializer';

--- a/src/lib/mermaid/parser.ts
+++ b/src/lib/mermaid/parser.ts
@@ -1,0 +1,497 @@
+import { diagramDefinitions } from './diagramDefinitions';
+import type {
+  MermaidDiagramConfig,
+  MermaidDiagramType,
+  MermaidEdge,
+  MermaidGraphModel,
+  MermaidNode,
+  MermaidNodeData,
+} from './types';
+
+const createPosition = (index: number): { x: number; y: number } => {
+  const column = index % 4;
+  const row = Math.floor(index / 4);
+  return { x: column * 220, y: row * 140 };
+};
+
+const cloneConfig = <T extends MermaidDiagramConfig>(config: T): T => ({ ...config });
+
+const createBaseModel = (type: MermaidDiagramType): MermaidGraphModel => {
+  const definition = diagramDefinitions[type];
+  return {
+    type,
+    config: cloneConfig(definition.defaultConfig) as MermaidDiagramConfig,
+    nodes: [],
+    edges: [],
+    warnings: [],
+  };
+};
+
+const sanitizeId = (id: string): string => id.replace(/[^A-Za-z0-9_]/g, '_');
+const sanitizeLabel = (value: string): string => value.replace(/^"|"$/g, '').trim();
+
+export const detectDiagramType = (source: string): MermaidDiagramType => {
+  const lines = source.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0 && !line.startsWith('%%'));
+  if (lines.length === 0) {
+    return 'flowchart';
+  }
+  const firstLine = lines[0].toLowerCase();
+  if (firstLine.startsWith('flowchart') || firstLine.startsWith('graph')) return 'flowchart';
+  if (firstLine.startsWith('sequencediagram')) return 'sequence';
+  if (firstLine.startsWith('classdiagram')) return 'class';
+  if (firstLine.startsWith('statediagram')) return 'state';
+  if (firstLine.startsWith('erdiagram')) return 'er';
+  if (firstLine.startsWith('gantt')) return 'gantt';
+  return 'flowchart';
+};
+
+const ensureNode = (model: MermaidGraphModel, id: string, variant: string, label: string, metadata?: Record<string, string>): MermaidNode => {
+  const existing = model.nodes.find((node) => node.id === id);
+  if (existing) {
+    if (label && existing.data.label === existing.id) {
+      existing.data.label = label;
+    }
+    if (metadata) {
+      existing.data.metadata = { ...(existing.data.metadata || {}), ...metadata };
+    }
+    return existing;
+  }
+
+  const node: MermaidNode = {
+    id,
+    type: 'default',
+    position: createPosition(model.nodes.length),
+    data: {
+      diagramType: model.type,
+      variant,
+      label: label || id,
+      metadata: metadata ? { ...metadata } : {},
+    },
+  };
+  model.nodes.push(node);
+  return node;
+};
+
+const addEdge = (model: MermaidGraphModel, source: string, target: string, variant: string, label?: string, metadata?: Record<string, string>): void => {
+  const edgeId = `edge_${model.edges.length}_${source}_${target}`;
+  const edge: MermaidEdge = {
+    id: edgeId,
+    source,
+    target,
+    data: {
+      diagramType: model.type,
+      variant,
+      label,
+      metadata: metadata ? { ...metadata } : {},
+    },
+  };
+  model.edges.push(edge);
+};
+
+const parseFlowchart = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('flowchart');
+  const lines = source.split(/\r?\n/);
+  const orientationPattern = /^(?:flowchart|graph)\s+([A-Za-z]{2})/i;
+  const nodePatterns: { variant: string; regex: RegExp }[] = [
+    { variant: 'subroutine', regex: /([A-Za-z0-9_]+)\s*\[\[([^\]]+)\]\]/g },
+    { variant: 'process', regex: /([A-Za-z0-9_]+)\s*\[([^\]]+)\]/g },
+    { variant: 'decision', regex: /([A-Za-z0-9_]+)\s*\{([^}]+)\}/g },
+    { variant: 'startEnd', regex: /([A-Za-z0-9_]+)\s*\(\(([^)]+)\)\)/g },
+    { variant: 'startEnd', regex: /([A-Za-z0-9_]+)\s*\(([^)]+)\)/g },
+    { variant: 'inputOutput', regex: /([A-Za-z0-9_]+)\s*\[\/([^/]+)\/\]/g },
+  ];
+  const edgePattern = /([A-Za-z0-9_]+)\s*([-\.=>ox]+)\s*(?:\|([^|]+)\|)?\s*([A-Za-z0-9_]+)/g;
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    const orientationMatch = trimmed.match(orientationPattern);
+    if (orientationMatch) {
+      model.config = { type: 'flowchart', orientation: orientationMatch[1].toUpperCase() as any };
+      return;
+    }
+    if (trimmed.startsWith('subgraph') || trimmed === 'end') {
+      return;
+    }
+
+    nodePatterns.forEach(({ variant, regex }) => {
+      let match: RegExpExecArray | null;
+      regex.lastIndex = 0;
+      while ((match = regex.exec(trimmed)) !== null) {
+        const id = sanitizeId(match[1]);
+        const label = sanitizeLabel(match[2]);
+        ensureNode(model, id, variant, label);
+      }
+    });
+
+    let match: RegExpExecArray | null;
+    edgePattern.lastIndex = 0;
+    while ((match = edgePattern.exec(trimmed)) !== null) {
+      const source = sanitizeId(match[1]);
+      const symbol = match[2];
+      const label = match[3] ? sanitizeLabel(match[3]) : undefined;
+      const target = sanitizeId(match[4]);
+
+      ensureNode(model, source, 'process', source);
+      ensureNode(model, target, 'process', target);
+
+      let variant = 'arrow';
+      if (symbol.includes('.')) {
+        variant = 'dashed';
+      } else if (symbol.includes('=')) {
+        variant = 'thick';
+      }
+
+      addEdge(model, source, target, variant, label);
+    }
+  });
+
+  return model;
+};
+
+const parseSequence = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('sequence');
+  const lines = source.split(/\r?\n/);
+  const config = model.config.type === 'sequence' ? model.config : { type: 'sequence', autoNumber: false };
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    if (trimmed.toLowerCase() === 'autonumber') {
+      config.autoNumber = true;
+      return;
+    }
+    const participantMatch = trimmed.match(/^(participant|actor|boundary|control|database)\s+([^\s]+)(?:\s+as\s+(.+))?/i);
+    if (participantMatch) {
+      const variant = participantMatch[1].toLowerCase();
+      const alias = sanitizeId(participantMatch[2]);
+      const label = participantMatch[3] ? sanitizeLabel(participantMatch[3]) : alias;
+      ensureNode(model, alias, variant, label, { alias });
+      return;
+    }
+    const messageMatch = trimmed.match(/^([A-Za-z0-9_]+)\s*([-.]*>>|[-.]*>)\s*([A-Za-z0-9_]+)(?:\s*:\s*(.+))?/);
+    if (messageMatch) {
+      const source = sanitizeId(messageMatch[1]);
+      const arrow = messageMatch[2];
+      const target = sanitizeId(messageMatch[3]);
+      const label = messageMatch[4] ? sanitizeLabel(messageMatch[4]) : undefined;
+
+      ensureNode(model, source, 'participant', source);
+      ensureNode(model, target, 'participant', target);
+
+      let variant: string = 'solid';
+      if (arrow.includes('--')) {
+        variant = 'dashed';
+      } else if (arrow.endsWith('>') && !arrow.endsWith('>>')) {
+        variant = 'open';
+      }
+
+      addEdge(model, source, target, variant, label);
+    }
+  });
+
+  model.config = config;
+  return model;
+};
+
+const parseClass = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('class');
+  const lines = source.split(/\r?\n/);
+  const directionPattern = /^direction\s+(TB|LR)/i;
+  const relationshipPattern = /([A-Za-z0-9_]+)\s+([<:o*]{0,2}[-.]+[>:o*]{0,2})\s+([A-Za-z0-9_]+)(?:\s*:\s*(.+))?/g;
+
+  let buffer = '';
+  let inClass = false;
+  let currentClass = '';
+  const classBody: string[] = [];
+
+const flushClass = () => {
+    if (!currentClass) return;
+    const stereotype = classBody.find((line) => line.startsWith('<<') && line.endsWith('>>')) || undefined;
+    const members = classBody
+      .filter((line) => line && line !== stereotype && !line.trim().includes('('))
+      .map((item) => item.trim())
+      .filter(Boolean);
+    const methods = classBody
+      .filter((line) => line && line !== stereotype && line.trim().includes('('))
+      .map((item) => item.trim())
+      .filter(Boolean);
+    let variant: string = 'class';
+    if (stereotype) {
+      if (stereotype.toLowerCase().includes('interface')) {
+        variant = 'interface';
+      } else if (stereotype.toLowerCase().includes('abstract')) {
+        variant = 'abstract';
+      }
+    }
+    const metadata: Record<string, string> = {};
+    if (stereotype) metadata.stereotype = stereotype;
+    if (members.length > 0) metadata.members = members.join('\n');
+    if (methods.length > 0) metadata.methods = methods.join('\n');
+    ensureNode(model, currentClass, variant, currentClass, metadata);
+    classBody.length = 0;
+    currentClass = '';
+    inClass = false;
+  };
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    const directionMatch = trimmed.match(directionPattern);
+    if (directionMatch) {
+      model.config = { type: 'class', direction: directionMatch[1] as any };
+      return;
+    }
+
+    if (trimmed.startsWith('class ') && trimmed.includes('{')) {
+      inClass = true;
+      currentClass = sanitizeId(trimmed.split(' ')[1]);
+      const bodyStart = trimmed.indexOf('{');
+      buffer = trimmed.slice(bodyStart + 1);
+      if (buffer.includes('}')) {
+        const [content] = buffer.split('}');
+        content.split('\n').forEach((lineContent) => classBody.push(lineContent.trim()));
+        flushClass();
+      }
+      return;
+    }
+
+    if (inClass) {
+      if (trimmed === '}') {
+        flushClass();
+        return;
+      }
+      classBody.push(trimmed);
+      return;
+    }
+
+    let match: RegExpExecArray | null;
+    relationshipPattern.lastIndex = 0;
+    while ((match = relationshipPattern.exec(trimmed)) !== null) {
+      const left = sanitizeId(match[1]);
+      const symbol = match[2];
+      const right = sanitizeId(match[3]);
+      const label = match[4] ? sanitizeLabel(match[4]) : undefined;
+
+      ensureNode(model, left, 'class', left);
+      ensureNode(model, right, 'class', right);
+
+      let variant: string = 'association';
+      if (symbol.includes('<|')) variant = 'inheritance';
+      else if (symbol.includes('*')) variant = 'composition';
+      else if (symbol.includes('o')) variant = 'aggregation';
+      else if (symbol.includes('.')) variant = 'dependency';
+
+      addEdge(model, left, right, variant, label);
+    }
+  });
+
+  flushClass();
+  return model;
+};
+
+const parseState = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('state');
+  const lines = source.split(/\r?\n/);
+  const directionPattern = /^direction\s+(TB|LR)/i;
+  const aliasPattern = /^state\s+"(.+?)"\s+as\s+([A-Za-z0-9_]+)/i;
+  const choicePattern = /^state\s+([A-Za-z0-9_]+)\s+<<choice>>/i;
+  const transitionPattern = /([A-Za-z0-9_\[\]*]+)\s*-->\s*([A-Za-z0-9_\[\]*]+)(?:\s*:\s*(.+))?/g;
+
+  const resolveStateId = (raw: string, role: 'source' | 'target'): { id: string; variant: 'start' | 'end' | 'state' } => {
+    const normalized = raw.replace(/\s+/g, '');
+    if (normalized === '[*]') {
+      if (role === 'source') {
+        return { id: 'state_start', variant: 'start' };
+      }
+      return { id: 'state_end', variant: 'end' };
+    }
+    return { id: sanitizeId(normalized), variant: 'state' };
+  };
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    const directionMatch = trimmed.match(directionPattern);
+    if (directionMatch) {
+      model.config = { type: 'state', direction: directionMatch[1] as any };
+      return;
+    }
+    const aliasMatch = trimmed.match(aliasPattern);
+    if (aliasMatch) {
+      const label = sanitizeLabel(aliasMatch[1]);
+      const id = sanitizeId(aliasMatch[2]);
+      ensureNode(model, id, 'state', label);
+      return;
+    }
+    const choiceMatch = trimmed.match(choicePattern);
+    if (choiceMatch) {
+      const id = sanitizeId(choiceMatch[1]);
+      ensureNode(model, id, 'choice', id);
+      return;
+    }
+
+    let match: RegExpExecArray | null;
+    transitionPattern.lastIndex = 0;
+    while ((match = transitionPattern.exec(trimmed)) !== null) {
+      const sourceRaw = match[1];
+      const targetRaw = match[2];
+      const label = match[3] ? sanitizeLabel(match[3]) : undefined;
+      const sourceInfo = resolveStateId(sourceRaw, 'source');
+      const targetInfo = resolveStateId(targetRaw, 'target');
+
+      ensureNode(model, sourceInfo.id, sourceInfo.variant, sourceInfo.variant === 'start' ? 'Start' : sourceInfo.id);
+      ensureNode(model, targetInfo.id, targetInfo.variant, targetInfo.variant === 'end' ? 'End' : targetInfo.id);
+
+      addEdge(model, sourceInfo.id, targetInfo.id, 'transition', label);
+    }
+  });
+
+  return model;
+};
+
+const parseEr = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('er');
+  const lines = source.split(/\r?\n/);
+  let currentEntity: string | null = null;
+  const attributes: string[] = [];
+
+  const flush = () => {
+    if (!currentEntity) return;
+    ensureNode(model, currentEntity, 'entity', currentEntity, {
+      attributes: attributes.join('\n'),
+    });
+    attributes.length = 0;
+    currentEntity = null;
+  };
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    if (trimmed.endsWith('{')) {
+      flush();
+      currentEntity = sanitizeId(trimmed.replace('{', '').trim());
+      return;
+    }
+    if (trimmed === '}') {
+      flush();
+      return;
+    }
+    const relMatch = trimmed.match(/([A-Za-z0-9_]+)\s+([|}o]{1,2}[-]{2}[|{o]{1,2})\s+([A-Za-z0-9_]+)(?:\s*:\s*(.+))?/);
+    if (relMatch) {
+      flush();
+      const left = sanitizeId(relMatch[1]);
+      const symbol = relMatch[2];
+      const right = sanitizeId(relMatch[3]);
+      const label = relMatch[4] ? sanitizeLabel(relMatch[4]) : undefined;
+
+      ensureNode(model, left, 'entity', left);
+      ensureNode(model, right, 'entity', right);
+
+      let variant = 'identifying';
+      if (symbol === '||--o{') variant = 'nonIdentifying';
+      else if (symbol === '||--|{') variant = 'oneToMany';
+      else if (symbol === '}o--o{') variant = 'manyToMany';
+
+      addEdge(model, left, right, variant, label);
+      return;
+    }
+    if (currentEntity) {
+      attributes.push(trimmed);
+    }
+  });
+
+  flush();
+  return model;
+};
+
+const parseGantt = (source: string): MermaidGraphModel => {
+  const model = createBaseModel('gantt');
+  const lines = source.split(/\r?\n/);
+  const config = model.config.type === 'gantt' ? model.config : diagramDefinitions.gantt.defaultConfig;
+  let currentSection = 'General';
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%%')) return;
+    if (trimmed.toLowerCase().startsWith('title ')) {
+      config.title = trimmed.slice(6).trim();
+      return;
+    }
+    if (trimmed.toLowerCase().startsWith('dateformat')) {
+      config.dateFormat = trimmed.split(' ')[1] || config.dateFormat;
+      return;
+    }
+    if (trimmed.toLowerCase().startsWith('axisformat')) {
+      config.axisFormat = trimmed.split(' ')[1] || config.axisFormat;
+      return;
+    }
+    if (trimmed.toLowerCase().startsWith('section ')) {
+      currentSection = trimmed.slice('section '.length).trim();
+      return;
+    }
+
+    const taskMatch = trimmed.match(/^([^:]+):(.+)$/);
+    if (taskMatch) {
+      const label = sanitizeLabel(taskMatch[1].trim());
+      const rest = taskMatch[2].split(',').map((token) => token.trim()).filter(Boolean);
+      let status = 'active';
+      let taskId = '';
+      const metadata: Record<string, string> = { section: currentSection };
+      const knownStatus = new Set(['done', 'active', 'crit', 'milestone']);
+
+      if (rest.length > 0 && knownStatus.has(rest[0] as any)) {
+        status = rest.shift() as string;
+      }
+      if (rest.length > 0) {
+        taskId = sanitizeId(rest.shift() as string);
+      }
+      if (rest.length > 0) {
+        metadata.start = rest.shift() as string;
+      }
+      if (rest.length > 0) {
+        const value = rest.shift() as string;
+        if (/\d+[dwmy]/i.test(value) || value.includes('after')) {
+          metadata.duration = value;
+        } else {
+          metadata.end = value;
+        }
+      }
+      if (rest.length > 0) {
+        metadata.dependsOn = rest.shift() as string;
+      }
+
+      metadata.status = status;
+      metadata.taskId = taskId || sanitizeId(label);
+
+      ensureNode(model, metadata.taskId, status === 'milestone' ? 'milestone' : 'task', label, metadata);
+    }
+  });
+
+  model.config = config;
+  return model;
+};
+
+export const parseMermaidSource = (source: string): MermaidGraphModel => {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return createBaseModel('flowchart');
+  }
+  const type = detectDiagramType(trimmed);
+  switch (type) {
+    case 'flowchart':
+      return parseFlowchart(trimmed);
+    case 'sequence':
+      return parseSequence(trimmed);
+    case 'class':
+      return parseClass(trimmed);
+    case 'state':
+      return parseState(trimmed);
+    case 'er':
+      return parseEr(trimmed);
+    case 'gantt':
+      return parseGantt(trimmed);
+    default:
+      return parseFlowchart(trimmed);
+  }
+};

--- a/src/lib/mermaid/serializer.ts
+++ b/src/lib/mermaid/serializer.ts
@@ -1,0 +1,297 @@
+import { diagramDefinitions } from './diagramDefinitions';
+import type {
+  MermaidDiagramConfig,
+  MermaidEdge,
+  MermaidGraphModel,
+  MermaidNode,
+  MermaidNodeData,
+} from './types';
+
+export interface MermaidSerializationResult {
+  code: string;
+  warnings: string[];
+}
+
+const escapeMermaidText = (value: string): string => value.replace(/"/g, '\\"');
+const sanitizeMultiline = (value: string): string => value.split(/\r?\n/).map((line) => line.trim()).join('\n');
+const getEdgeLabel = (edge: MermaidEdge): string => edge.data.label ?? edge.data.metadata?.label ?? '';
+
+const serializeFlowchart = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const config = model.config.type === 'flowchart' ? model.config : diagramDefinitions.flowchart.defaultConfig;
+  const lines: string[] = [`flowchart ${config.orientation}`];
+  const warnings: string[] = [];
+
+  model.nodes.forEach((node) => {
+    const { variant, label } = node.data;
+    const safeLabel = escapeMermaidText(label || node.id);
+
+    let declaration = '';
+    switch (variant) {
+      case 'startEnd':
+        declaration = `${node.id}(${safeLabel})`;
+        break;
+      case 'decision':
+        declaration = `${node.id}{${safeLabel}}`;
+        break;
+      case 'inputOutput':
+        declaration = `${node.id}[/"${safeLabel}"/]`;
+        break;
+      case 'subroutine':
+        declaration = `${node.id}[[${safeLabel}]]`;
+        break;
+      case 'process':
+      default:
+        declaration = `${node.id}[${safeLabel}]`;
+        break;
+    }
+    lines.push(declaration);
+  });
+
+  model.edges.forEach((edge) => {
+    const { variant } = edge.data;
+    let connector = '-->';
+    if (variant === 'dashed') {
+      connector = '-.->';
+    } else if (variant === 'thick') {
+      connector = '==>';
+    }
+    const label = getEdgeLabel(edge);
+    const text = label ? `|${label}|` : '';
+    lines.push(`${edge.source} ${connector}${text} ${edge.target}`.trim());
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+const sequenceVariantKeyword: Record<string, string> = {
+  participant: 'participant',
+  actor: 'actor',
+  boundary: 'boundary',
+  control: 'control',
+  database: 'database',
+};
+
+const serializeSequence = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const config = model.config.type === 'sequence' ? model.config : diagramDefinitions.sequence.defaultConfig;
+  const lines: string[] = ['sequenceDiagram'];
+  const warnings: string[] = [];
+
+  if (config.autoNumber) {
+    lines.push('autonumber');
+  }
+
+  model.nodes.forEach((node) => {
+    const keyword = sequenceVariantKeyword[node.data.variant] || 'participant';
+    const alias = node.data.metadata?.alias?.trim();
+    if (alias && alias !== node.id) {
+      lines.push(`${keyword} ${alias} as ${escapeMermaidText(node.data.label)}`);
+    } else {
+      lines.push(`${keyword} ${node.id} as ${escapeMermaidText(node.data.label)}`);
+    }
+  });
+
+  model.edges.forEach((edge) => {
+    let connector = '->>';
+    if (edge.data.variant === 'dashed') connector = '-->>';
+    if (edge.data.variant === 'open') connector = '->';
+    const label = getEdgeLabel(edge);
+    const labelText = label ? `: ${label}` : '';
+    lines.push(`${edge.source} ${connector} ${edge.target}${labelText}`);
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+const classRelationshipSymbols: Record<string, string> = {
+  inheritance: '<|--',
+  composition: '*--',
+  aggregation: 'o--',
+  association: '--',
+  dependency: '..>'
+};
+
+const serializeClass = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const config = model.config.type === 'class' ? model.config : diagramDefinitions.class.defaultConfig;
+  const lines: string[] = ['classDiagram'];
+  const warnings: string[] = [];
+
+  if (config.direction) {
+    lines.push(`direction ${config.direction}`);
+  }
+
+  model.nodes.forEach((node) => {
+    const metadata = node.data.metadata || {};
+    const bodyLines: string[] = [];
+    if (metadata.stereotype) {
+      bodyLines.push(metadata.stereotype);
+    }
+    if (metadata.members) {
+      bodyLines.push(...sanitizeMultiline(metadata.members).split('\n').filter(Boolean));
+    }
+    if (metadata.methods) {
+      bodyLines.push(...sanitizeMultiline(metadata.methods).split('\n').filter(Boolean));
+    }
+    if (bodyLines.length > 0) {
+      lines.push(`class ${node.id} {`);
+      bodyLines.forEach((line) => lines.push(`  ${line}`));
+      lines.push('}');
+    } else {
+      lines.push(`class ${node.id}`);
+    }
+    if (node.data.label && node.data.label !== node.id) {
+      lines.push(`${node.id} : ${node.data.label}`);
+    }
+  });
+
+  model.edges.forEach((edge) => {
+    const symbol = classRelationshipSymbols[edge.data.variant] || '--';
+    const label = getEdgeLabel(edge);
+    const labelText = label ? ` : ${label}` : '';
+    lines.push(`${edge.source} ${symbol} ${edge.target}${labelText}`);
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+const serializeState = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const config = model.config.type === 'state' ? model.config : diagramDefinitions.state.defaultConfig;
+  const lines: string[] = ['stateDiagram-v2'];
+  const warnings: string[] = [];
+
+  if (config.direction) {
+    lines.push(`direction ${config.direction}`);
+  }
+
+  const nodeMap = new Map<string, MermaidNodeData>();
+  model.nodes.forEach((node) => {
+    nodeMap.set(node.id, node.data);
+    if (node.data.variant === 'state') {
+      if (node.data.label && node.data.label !== node.id) {
+        lines.push(`state "${escapeMermaidText(node.data.label)}" as ${node.id}`);
+      } else {
+        lines.push(`state ${node.id}`);
+      }
+    } else if (node.data.variant === 'choice') {
+      lines.push(`state ${node.id} <<choice>>`);
+    }
+  });
+
+  model.edges.forEach((edge) => {
+    const sourceData = nodeMap.get(edge.source);
+    const targetData = nodeMap.get(edge.target);
+    const source = sourceData?.variant === 'start' ? '[*]' : sourceData?.variant === 'end' ? '[*]' : edge.source;
+    const target = targetData?.variant === 'end' ? '[*]' : targetData?.variant === 'start' ? '[*]' : edge.target;
+    const label = getEdgeLabel(edge);
+    const labelText = label ? ` : ${label}` : '';
+    lines.push(`${source} --> ${target}${labelText}`);
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+const erRelationshipSymbols: Record<string, string> = {
+  identifying: '||--||',
+  nonIdentifying: '||--o{',
+  oneToMany: '||--|{',
+  manyToMany: '}o--o{',
+};
+
+const serializeEr = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const lines: string[] = ['erDiagram'];
+  const warnings: string[] = [];
+
+  model.nodes.forEach((node) => {
+    const metadata = node.data.metadata || {};
+    const attrs = metadata.attributes ? sanitizeMultiline(metadata.attributes).split('\n').filter(Boolean) : [];
+    if (attrs.length > 0) {
+      lines.push(`${node.id} {`);
+      attrs.forEach((attr) => lines.push(`  ${attr}`));
+      lines.push('}');
+    } else {
+      lines.push(node.id);
+    }
+  });
+
+  model.edges.forEach((edge) => {
+    const symbol = erRelationshipSymbols[edge.data.variant] || '--';
+    const label = getEdgeLabel(edge);
+    const labelText = label ? ` : ${label}` : '';
+    lines.push(`${edge.source} ${symbol} ${edge.target}${labelText}`);
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+const serializeGantt = (model: MermaidGraphModel): MermaidSerializationResult => {
+  const config = model.config.type === 'gantt' ? model.config : diagramDefinitions.gantt.defaultConfig;
+  const lines: string[] = ['gantt'];
+  const warnings: string[] = [];
+
+  if (config.title) {
+    lines.push(`title ${config.title}`);
+  }
+  lines.push(`dateFormat ${config.dateFormat}`);
+  lines.push(`axisFormat ${config.axisFormat}`);
+
+  const sections = new Map<string, MermaidNode[]>();
+  model.nodes.forEach((node) => {
+    const section = node.data.metadata?.section || 'General';
+    if (!sections.has(section)) {
+      sections.set(section, []);
+    }
+    sections.get(section)!.push(node);
+  });
+
+  const knownStatuses = new Set(['done', 'active', 'crit', 'milestone']);
+
+  sections.forEach((nodes, sectionName) => {
+    lines.push(`section ${sectionName}`);
+    nodes.forEach((node) => {
+      const metadata = node.data.metadata || {};
+      const status = metadata.status && knownStatuses.has(metadata.status) ? `${metadata.status}, ` : '';
+      const taskId = metadata.taskId || node.id;
+      const timingParts: string[] = [];
+      if (metadata.start) {
+        timingParts.push(metadata.start);
+      }
+      if (metadata.end) {
+        timingParts.push(metadata.end);
+      } else if (metadata.duration) {
+        timingParts.push(metadata.duration);
+      }
+      if (metadata.dependsOn) {
+        timingParts.push(metadata.dependsOn);
+      }
+      const timing = timingParts.length > 0 ? `, ${timingParts.join(', ')}` : '';
+      lines.push(`${node.data.label} :${status}${taskId}${timing}`);
+    });
+  });
+
+  return { code: lines.join('\n'), warnings };
+};
+
+export const serializeMermaid = (model: MermaidGraphModel): MermaidSerializationResult => {
+  switch (model.type) {
+    case 'flowchart':
+      return serializeFlowchart(model);
+    case 'sequence':
+      return serializeSequence(model);
+    case 'class':
+      return serializeClass(model);
+    case 'state':
+      return serializeState(model);
+    case 'er':
+      return serializeEr(model);
+    case 'gantt':
+      return serializeGantt(model);
+    default:
+      return { code: model.nodes.map((node) => node.data.label).join('\n'), warnings: ['未対応の図種類です'] };
+  }
+};
+
+export const ensureConfig = (config: MermaidDiagramConfig): MermaidDiagramConfig => {
+  if (!config) {
+    return diagramDefinitions.flowchart.defaultConfig;
+  }
+  return config;
+};

--- a/src/lib/mermaid/types.ts
+++ b/src/lib/mermaid/types.ts
@@ -1,0 +1,78 @@
+import type { Edge, Node } from 'reactflow';
+
+/** Mermaidで扱う主要な図の種類 */
+export type MermaidDiagramType =
+  | 'flowchart'
+  | 'sequence'
+  | 'class'
+  | 'state'
+  | 'er'
+  | 'gantt';
+
+/** ノード共通のデータ構造 */
+export interface MermaidNodeData {
+  /** 図の種類（flowchart, sequenceなど） */
+  diagramType: MermaidDiagramType;
+  /** 図ごとのノード種別（例: startEnd, participantなど） */
+  variant: string;
+  /** 表示ラベル */
+  label: string;
+  /** 補助説明（UI表示用） */
+  description?: string;
+  /** 追加メタデータ（自由形式） */
+  metadata?: Record<string, string>;
+}
+
+/** エッジ共通のデータ構造 */
+export interface MermaidEdgeData {
+  /** 図の種類 */
+  diagramType: MermaidDiagramType;
+  /** 図ごとのエッジ種別（例: arrow, dashed, inheritanceなど） */
+  variant: string;
+  /** エッジに表示するラベル */
+  label?: string;
+  /** 追加メタデータ（自由形式） */
+  metadata?: Record<string, string>;
+}
+
+/** React Flowで扱うノード型 */
+export type MermaidNode = Node<MermaidNodeData>;
+/** React Flowで扱うエッジ型 */
+export type MermaidEdge = Edge<MermaidEdgeData>;
+
+/** フローチャートの向き */
+export type FlowchartOrientation = 'TB' | 'TD' | 'BT' | 'LR' | 'RL';
+/** シーケンス図の矢印種別 */
+export type SequenceMessageStyle = 'solid' | 'dashed' | 'open';
+/** クラス図の関連種別 */
+export type ClassRelationshipVariant =
+  | 'inheritance'
+  | 'composition'
+  | 'aggregation'
+  | 'association'
+  | 'dependency';
+/** ステート図の方向 */
+export type StateDiagramDirection = 'TB' | 'LR';
+
+/** 図種別ごとの設定値 */
+export type MermaidDiagramConfig =
+  | { type: 'flowchart'; orientation: FlowchartOrientation }
+  | { type: 'sequence'; autoNumber: boolean }
+  | { type: 'class'; direction: StateDiagramDirection }
+  | { type: 'state'; direction: StateDiagramDirection }
+  | { type: 'er' }
+  | { type: 'gantt'; dateFormat: string; axisFormat: string; title?: string };
+
+/** React Flow上の状態をMermaidソースへ変換するためのモデル */
+export interface MermaidGraphModel {
+  /** 図の種類 */
+  type: MermaidDiagramType;
+  /** 図種別ごとの設定 */
+  config: MermaidDiagramConfig;
+  /** React Flowノード */
+  nodes: MermaidNode[];
+  /** React Flowエッジ */
+  edges: MermaidEdge[];
+  /** 変換時に発生した警告 */
+  warnings: string[];
+}


### PR DESCRIPTION
## Summary
- add a React Flow based Mermaid designer UI with palette, property inspector, and live preview/code panes
- implement typed diagram templates plus parser and serializer logic covering flowchart, sequence, class, state, ER, and Gantt diagrams
- wire the new designer into the Mermaid preview workflow and add the reactflow dependency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d26c7e8cd4832fa0666f3f856e5728