### PR TITLE
Fix ReactFlow import by dynamically loading Mermaid designer

### DIFF
--- a/src/components/mermaid/MermaidDesigner.tsx
+++ b/src/components/mermaid/MermaidDesigner.tsx
@@ -50,7 +50,7 @@ import type {
 } from '@/lib/mermaid/types';
 import MermaidPreview from '@/components/preview/MermaidPreview';
 
-interface MermaidDesignerProps {
+export interface MermaidDesignerProps {
   tabId: string;
   fileName: string;
   content: string;

--- a/src/components/preview/DataPreview.tsx
+++ b/src/components/preview/DataPreview.tsx
@@ -9,7 +9,6 @@
  */
 'use client';
 
-
 /**
  * DataPreview.tsx
  * このファイルは、CSV/TSV/JSON/YAML/Parquet/Markdown/Mermaid/PDF/ipynbなど多様なデータを解析し、
@@ -20,16 +19,16 @@
  * - 分析モード切替
  * - エラー・ローディング表示
  */
-'use client';
 
 import React, { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { useEditorStore } from '@/store/editorStore';
 import { parseCSV, parseJSON, parseYAML, parseParquet, flattenNestedObjects, parseMermaid } from '@/lib/dataPreviewUtils';
 import { formatData } from '@/lib/dataFormatUtils';
 import DataTable from './DataTable';
 import EditableDataTable from './EditableDataTable';
 import ObjectViewer from './ObjectViewer';
-import MermaidDesigner from '@/components/mermaid/MermaidDesigner';
+import type { MermaidDesignerProps } from '@/components/mermaid/MermaidDesigner';
 import IpynbPreview from './IpynbPreview';
 import PdfPreview from './PdfPreview';
 import ExcelPreview from './ExcelPreview';
@@ -37,6 +36,18 @@ import ExportModal from './ExportModal';
 import { IoAlertCircleOutline, IoCodeSlash, IoEye, IoAnalytics, IoLayers, IoGrid, IoSave, IoClose, IoDownload } from 'react-icons/io5';
 import * as XLSX from 'xlsx';
 import { Document, Packer, Paragraph } from 'docx';
+
+const MermaidDesigner = dynamic<MermaidDesignerProps>(
+  () => import('@/components/mermaid/MermaidDesigner'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full items-center justify-center rounded border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        Mermaidデザイナーを読み込み中...
+      </div>
+    ),
+  },
+);
 
 interface DataPreviewProps {
   tabId: string;


### PR DESCRIPTION
## Summary
- load the Mermaid designer component with `next/dynamic` so it only runs on the client and shows a loading fallback
- export the Mermaid designer props interface for use with the dynamic import wrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d278c2a41c832f9bf5c5bbc1308980