### PR TITLE
Fix Mermaid initialization race and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm run dev
 ### Markdown と Mermaid
 - Markdown プレビューはリアルタイム同期、見出し目次の自動生成、折り畳み、外部リンクの新規タブ開きを備えています。
 - Docx ライブラリを利用した Word 出力ボタンを搭載。Markdown 内の ```mermaid``` コードブロックは自動的にダイアグラム化されます。
-- Mermaid プレビューはズーム、フィット、SVG/PNG での保存、クリップボードコピーをサポートしており、エディタとの分割表示でも利用できます。
+- Mermaid プレビューは初回アクセス時にライブラリを動的読み込みし、読み込み状況表示と自動リトライで安定化。ズーム、フィット、SVG/PNG での保存、クリップボードコピーをサポートしており、エディタとの分割表示でも利用できます。
 
 ### データプレビューと編集
 - **対応形式**：CSV、TSV、JSON、YAML、Parquet*¹、Excel（.xlsx/.xls）、Jupyter Notebook (.ipynb)、PDF*²、HTML/Markdown。


### PR DESCRIPTION
## Summary
- guard Mermaid initialization with a shared promise so concurrent renders wait for the same dynamic import and retry correctly
- keep a fallback for the module default export and persist the initialized instance once ready
- document the stabilized Mermaid preview loading flow in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d27e88d248832faf2044c79ec91a97