### PR TITLE
feat: improve flowchart node shapes and handles

### DIFF
--- a/src/components/mermaid/MermaidDesigner.tsx
+++ b/src/components/mermaid/MermaidDesigner.tsx
@@ -44,6 +44,7 @@ import MermaidPreview from '@/components/preview/MermaidPreview';
 import InteractiveMermaidCanvas from './InteractiveMermaidCanvas';
 import GroupOverlays from './GroupOverlays';
 import MermaidEdgeComponent from './MermaidEdge';
+import MermaidNodeComponent from './MermaidNode';
 
 export interface MermaidDesignerProps {
   tabId: string;
@@ -82,6 +83,7 @@ const createEdgeId = (): string => `edge_${Date.now().toString(36)}`;
 
 const PERSISTENT_METADATA_KEYS = ['sequence', 'command'];
 
+const MERMAID_NODE_TYPE = 'mermaid-node';
 const MERMAID_EDGE_TYPE = 'mermaid-edge';
 
 const expandShortHex = (value: string): string =>
@@ -747,7 +749,7 @@ const MermaidDesigner: React.FC<MermaidDesignerProps> = ({ tabId, fileName, cont
 
           const newNode: MermaidNode = {
             id,
-            type: 'default',
+            type: MERMAID_NODE_TYPE,
             position: defaultPosition,
             data: {
               diagramType,
@@ -1312,9 +1314,19 @@ const MermaidDesigner: React.FC<MermaidDesignerProps> = ({ tabId, fileName, cont
     return edgeTemplates.find((template) => template.variant === selectedEdge.data.variant);
   }, [selectedEdge, edgeTemplates]);
 
-  const edgeTypes = useMemo(() => ({
-    [MERMAID_EDGE_TYPE]: MermaidEdgeComponent,
-  }), []);
+  const nodeTypes = useMemo(
+    () => ({
+      [MERMAID_NODE_TYPE]: MermaidNodeComponent,
+    }),
+    [],
+  );
+
+  const edgeTypes = useMemo(
+    () => ({
+      [MERMAID_EDGE_TYPE]: MermaidEdgeComponent,
+    }),
+    [],
+  );
 
   const defaultEdgeOptions = useMemo(
     () => ({
@@ -1828,6 +1840,7 @@ const MermaidDesigner: React.FC<MermaidDesignerProps> = ({ tabId, fileName, cont
           <ReactFlow
             nodes={nodes}
             edges={edges}
+            nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             defaultEdgeOptions={defaultEdgeOptions}
             onNodesChange={handleNodesChange}

--- a/src/components/mermaid/MermaidNode.tsx
+++ b/src/components/mermaid/MermaidNode.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { MermaidNodeData } from '@/lib/mermaid/types';
+
+const handleStyle: CSSProperties = {
+  width: 12,
+  height: 12,
+  background: '#2563eb',
+  borderRadius: '9999px',
+  border: '2px solid #ffffff',
+};
+
+const wrapLabel = (label: string, color: string) => (
+  <span
+    className="text-sm font-medium"
+    style={{ color, textAlign: 'center', wordBreak: 'break-word', display: 'block' }}
+  >
+    {label}
+  </span>
+);
+
+const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, selected }) => {
+  const handlePositions = useMemo(() => ({
+    targetTop: { ...handleStyle, left: '30%' } as CSSProperties,
+    sourceTop: { ...handleStyle, left: '70%' } as CSSProperties,
+    targetBottom: { ...handleStyle, left: '30%' } as CSSProperties,
+    sourceBottom: { ...handleStyle, left: '70%' } as CSSProperties,
+    targetLeft: { ...handleStyle, top: '30%' } as CSSProperties,
+    sourceLeft: { ...handleStyle, top: '70%' } as CSSProperties,
+    targetRight: { ...handleStyle, top: '30%' } as CSSProperties,
+    sourceRight: { ...handleStyle, top: '70%' } as CSSProperties,
+  }), []);
+
+  const { fillColor, strokeColor, textColor } = useMemo(() => {
+    const metadata = data.metadata ?? {};
+    const fill = typeof metadata.fillColor === 'string' ? metadata.fillColor : '#ffffff';
+    const stroke = typeof metadata.strokeColor === 'string' ? metadata.strokeColor : '#1f2937';
+    const text = typeof metadata.textColor === 'string' ? metadata.textColor : '#111827';
+    return { fillColor: fill, strokeColor: stroke, textColor: text };
+  }, [data.metadata]);
+
+  const baseBoxShadow = selected ? '0 0 0 3px rgba(37, 99, 235, 0.35)' : undefined;
+
+  const isFlowchart = data.diagramType === 'flowchart';
+
+  let content: React.ReactNode;
+
+  if (isFlowchart && data.variant === 'startEnd') {
+    content = (
+      <div
+        className="flex items-center justify-center"
+        style={{
+          background: fillColor,
+          border: `2px solid ${strokeColor}`,
+          borderRadius: '9999px',
+          minWidth: 96,
+          minHeight: 96,
+          padding: '12px 16px',
+          boxShadow: baseBoxShadow,
+        }}
+      >
+        {wrapLabel(data.label, textColor)}
+      </div>
+    );
+  } else if (isFlowchart && data.variant === 'decision') {
+    content = (
+      <div className="relative flex items-center justify-center" style={{ width: 120, height: 120 }}>
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            background: fillColor,
+            border: `2px solid ${strokeColor}`,
+            transform: 'rotate(45deg)',
+            borderRadius: 12,
+            boxShadow: baseBoxShadow,
+          }}
+        />
+        <div className="absolute inset-0 flex items-center justify-center" style={{ pointerEvents: 'none' }}>
+          {wrapLabel(data.label, textColor)}
+        </div>
+      </div>
+    );
+  } else {
+    content = (
+      <div
+        className="flex items-center justify-center"
+        style={{
+          background: fillColor,
+          border: `2px solid ${strokeColor}`,
+          borderRadius: 12,
+          minWidth: isFlowchart ? 140 : undefined,
+          minHeight: isFlowchart ? 72 : undefined,
+          padding: isFlowchart ? '12px 16px' : '8px 12px',
+          boxShadow: baseBoxShadow,
+        }}
+      >
+        {wrapLabel(data.label, textColor)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {content}
+      <Handle id="target-top" type="target" position={Position.Top} style={handlePositions.targetTop} />
+      <Handle id="target-bottom" type="target" position={Position.Bottom} style={handlePositions.targetBottom} />
+      <Handle id="target-left" type="target" position={Position.Left} style={handlePositions.targetLeft} />
+      <Handle id="target-right" type="target" position={Position.Right} style={handlePositions.targetRight} />
+      <Handle id="source-top" type="source" position={Position.Top} style={handlePositions.sourceTop} />
+      <Handle id="source-bottom" type="source" position={Position.Bottom} style={handlePositions.sourceBottom} />
+      <Handle id="source-left" type="source" position={Position.Left} style={handlePositions.sourceLeft} />
+      <Handle id="source-right" type="source" position={Position.Right} style={handlePositions.sourceRight} />
+    </div>
+  );
+};
+
+export default MermaidNodeComponent;

--- a/src/lib/mermaid/parser.ts
+++ b/src/lib/mermaid/parser.ts
@@ -75,7 +75,7 @@ const ensureNode = (model: MermaidGraphModel, id: string, variant: string, label
 
   const node: MermaidNode = {
     id,
-    type: 'default',
+    type: 'mermaid-node',
     position: createPosition(model.nodes.length),
     data: {
       diagramType: model.type,
@@ -629,7 +629,7 @@ const parseGitGraph = (source: string): MermaidGraphModel => {
     const normalizedLabel = label.trim().length > 0 ? label.trim() : variant;
     const node: MermaidNode = {
       id: nodeId,
-      type: 'default',
+      type: 'mermaid-node',
       position: { x: 160, y: index * 100 },
       data: {
         diagramType: 'gitGraph',


### PR DESCRIPTION
## Summary
- introduce a dedicated Mermaid node component that renders flowchart start/end nodes as circles and decision nodes as diamonds while respecting theme colors
- expose handles on all four sides of nodes so edges can be drawn from the left and right as well as the top and bottom
- update the designer and parser to use the new node type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a0ae1798832fb455a22cab8d4b17