### PR TITLE
feat(flowchart): add edge orientation controls

### DIFF
--- a/src/components/mermaid/EdgeHandleOrientationContext.ts
+++ b/src/components/mermaid/EdgeHandleOrientationContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export type EdgeHandleOrientation = 'vertical' | 'horizontal';
+
+export const EdgeHandleOrientationContext = createContext<EdgeHandleOrientation>('vertical');
+
+export const useEdgeHandleOrientation = (): EdgeHandleOrientation => useContext(EdgeHandleOrientationContext);

--- a/src/components/mermaid/MermaidNode.tsx
+++ b/src/components/mermaid/MermaidNode.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import type { CSSProperties } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import type { MermaidNodeData } from '@/lib/mermaid/types';
+import { useEdgeHandleOrientation } from './EdgeHandleOrientationContext';
 
 const handleStyle: CSSProperties = {
   width: 12,
@@ -23,16 +24,22 @@ const wrapLabel = (label: string, color: string) => (
 );
 
 const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, selected }) => {
-  const handlePositions = useMemo(() => ({
-    targetTop: { ...handleStyle, left: '30%' } as CSSProperties,
-    sourceTop: { ...handleStyle, left: '70%' } as CSSProperties,
-    targetBottom: { ...handleStyle, left: '30%' } as CSSProperties,
-    sourceBottom: { ...handleStyle, left: '70%' } as CSSProperties,
-    targetLeft: { ...handleStyle, top: '30%' } as CSSProperties,
-    sourceLeft: { ...handleStyle, top: '70%' } as CSSProperties,
-    targetRight: { ...handleStyle, top: '30%' } as CSSProperties,
-    sourceRight: { ...handleStyle, top: '70%' } as CSSProperties,
-  }), []);
+  const handlePositions = useMemo(
+    () => ({
+      targetTop: { ...handleStyle, left: '30%' } as CSSProperties,
+      sourceTop: { ...handleStyle, left: '70%' } as CSSProperties,
+      targetBottom: { ...handleStyle, left: '30%' } as CSSProperties,
+      sourceBottom: { ...handleStyle, left: '70%' } as CSSProperties,
+      targetLeft: { ...handleStyle, top: '30%' } as CSSProperties,
+      sourceLeft: { ...handleStyle, top: '70%' } as CSSProperties,
+      targetRight: { ...handleStyle, top: '30%' } as CSSProperties,
+      sourceRight: { ...handleStyle, top: '70%' } as CSSProperties,
+    }),
+    [],
+  );
+
+  const edgeHandleOrientation = useEdgeHandleOrientation();
+  const isVerticalHandles = edgeHandleOrientation === 'vertical';
 
   const { fillColor, strokeColor, textColor } = useMemo(() => {
     const metadata = data.metadata ?? {};
@@ -106,14 +113,21 @@ const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, sele
   return (
     <div className="relative">
       {content}
-      <Handle id="target-top" type="target" position={Position.Top} style={handlePositions.targetTop} />
-      <Handle id="target-bottom" type="target" position={Position.Bottom} style={handlePositions.targetBottom} />
-      <Handle id="target-left" type="target" position={Position.Left} style={handlePositions.targetLeft} />
-      <Handle id="target-right" type="target" position={Position.Right} style={handlePositions.targetRight} />
-      <Handle id="source-top" type="source" position={Position.Top} style={handlePositions.sourceTop} />
-      <Handle id="source-bottom" type="source" position={Position.Bottom} style={handlePositions.sourceBottom} />
-      <Handle id="source-left" type="source" position={Position.Left} style={handlePositions.sourceLeft} />
-      <Handle id="source-right" type="source" position={Position.Right} style={handlePositions.sourceRight} />
+      {isVerticalHandles ? (
+        <>
+          <Handle id="target-top" type="target" position={Position.Top} style={handlePositions.targetTop} />
+          <Handle id="target-bottom" type="target" position={Position.Bottom} style={handlePositions.targetBottom} />
+          <Handle id="source-top" type="source" position={Position.Top} style={handlePositions.sourceTop} />
+          <Handle id="source-bottom" type="source" position={Position.Bottom} style={handlePositions.sourceBottom} />
+        </>
+      ) : (
+        <>
+          <Handle id="target-left" type="target" position={Position.Left} style={handlePositions.targetLeft} />
+          <Handle id="target-right" type="target" position={Position.Right} style={handlePositions.targetRight} />
+          <Handle id="source-left" type="source" position={Position.Left} style={handlePositions.sourceLeft} />
+          <Handle id="source-right" type="source" position={Position.Right} style={handlePositions.sourceRight} />
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a shared context so nodes can react to the selected edge handle orientation and surface a palette dropdown for switching vertical or horizontal attachments
- update edge creation, updates, and auto-layout logic to honor the selected orientation and adjust horizontal layouts when needed
- hide unused node handles so flowchart nodes only expose the relevant connection points for the chosen orientation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b026d9b8832fb8035152e27fd600