### PR TITLE
refactor(flowchart): simplify handles and preview scrolling

### DIFF
--- a/src/components/mermaid/MermaidNode.tsx
+++ b/src/components/mermaid/MermaidNode.tsx
@@ -23,16 +23,31 @@ const wrapLabel = (label: string, color: string) => (
 );
 
 const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, selected }) => {
-  const handlePositions = useMemo(() => ({
-    targetTop: { ...handleStyle, left: '30%' } as CSSProperties,
-    sourceTop: { ...handleStyle, left: '70%' } as CSSProperties,
-    targetBottom: { ...handleStyle, left: '30%' } as CSSProperties,
-    sourceBottom: { ...handleStyle, left: '70%' } as CSSProperties,
-    targetLeft: { ...handleStyle, top: '30%' } as CSSProperties,
-    sourceLeft: { ...handleStyle, top: '70%' } as CSSProperties,
-    targetRight: { ...handleStyle, top: '30%' } as CSSProperties,
-    sourceRight: { ...handleStyle, top: '70%' } as CSSProperties,
-  }), []);
+  const handlePositions = useMemo(
+    () => ({
+      top: {
+        ...handleStyle,
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+      } as CSSProperties,
+      bottom: {
+        ...handleStyle,
+        left: '50%',
+        transform: 'translate(-50%, 50%)',
+      } as CSSProperties,
+      left: {
+        ...handleStyle,
+        top: '50%',
+        transform: 'translate(-50%, -50%)',
+      } as CSSProperties,
+      right: {
+        ...handleStyle,
+        top: '50%',
+        transform: 'translate(50%, -50%)',
+      } as CSSProperties,
+    }),
+    [],
+  );
 
   const { fillColor, strokeColor, textColor } = useMemo(() => {
     const metadata = data.metadata ?? {};
@@ -48,7 +63,10 @@ const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, sele
 
   let content: React.ReactNode;
 
-  if (isFlowchart && data.variant === 'startEnd') {
+  const isCircular = isFlowchart && data.variant === 'startEnd';
+  const isDecision = isFlowchart && data.variant === 'decision';
+
+  if (isCircular) {
     content = (
       <div
         className="flex items-center justify-center"
@@ -65,7 +83,7 @@ const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, sele
         {wrapLabel(data.label, textColor)}
       </div>
     );
-  } else if (isFlowchart && data.variant === 'decision') {
+  } else if (isDecision) {
     content = (
       <div className="relative flex items-center justify-center" style={{ width: 120, height: 120 }}>
         <div
@@ -103,17 +121,41 @@ const MermaidNodeComponent: React.FC<NodeProps<MermaidNodeData>> = ({ data, sele
     );
   }
 
+  const containerStyle: CSSProperties = isCircular || isDecision
+    ? { background: 'transparent', border: 'none', padding: 0 }
+    : {};
+
   return (
-    <div className="relative">
+    <div className="relative" style={containerStyle}>
       {content}
-      <Handle id="target-top" type="target" position={Position.Top} style={handlePositions.targetTop} />
-      <Handle id="target-bottom" type="target" position={Position.Bottom} style={handlePositions.targetBottom} />
-      <Handle id="target-left" type="target" position={Position.Left} style={handlePositions.targetLeft} />
-      <Handle id="target-right" type="target" position={Position.Right} style={handlePositions.targetRight} />
-      <Handle id="source-top" type="source" position={Position.Top} style={handlePositions.sourceTop} />
-      <Handle id="source-bottom" type="source" position={Position.Bottom} style={handlePositions.sourceBottom} />
-      <Handle id="source-left" type="source" position={Position.Left} style={handlePositions.sourceLeft} />
-      <Handle id="source-right" type="source" position={Position.Right} style={handlePositions.sourceRight} />
+      <Handle
+        id="top"
+        type="source"
+        position={Position.Top}
+        style={handlePositions.top}
+        isConnectableEnd
+      />
+      <Handle
+        id="bottom"
+        type="source"
+        position={Position.Bottom}
+        style={handlePositions.bottom}
+        isConnectableEnd
+      />
+      <Handle
+        id="left"
+        type="source"
+        position={Position.Left}
+        style={handlePositions.left}
+        isConnectableEnd
+      />
+      <Handle
+        id="right"
+        type="source"
+        position={Position.Right}
+        style={handlePositions.right}
+        isConnectableEnd
+      />
     </div>
   );
 };

--- a/src/components/preview/MermaidPreview.tsx
+++ b/src/components/preview/MermaidPreview.tsx
@@ -298,7 +298,11 @@ const MermaidPreview: React.FC<MermaidPreviewProps> = ({ content, fileName }) =>
       </div>
 
       {/* コンテンツ */}
-      <div className="flex-1 overflow-auto relative" ref={containerRef} style={{ minHeight: 0 }}>
+      <div
+        className="flex-1 relative overflow-x-auto overflow-y-auto"
+        ref={containerRef}
+        style={{ minHeight: 0 }}
+      >
         {error && (
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
@@ -319,9 +323,9 @@ const MermaidPreview: React.FC<MermaidPreviewProps> = ({ content, fileName }) =>
         )}
 
         {!error && svg && (
-          <div 
-            className="p-4 overflow-auto"
-            style={{ 
+          <div
+            className="p-4"
+            style={{
               minWidth: 'max-content',
               minHeight: 'max-content'
             }}


### PR DESCRIPTION
## Summary
- normalize stored handle ids and update edge creation/updating to respect whichever side the user connects from, dropping the orientation toggle
- render flowchart nodes with four bidirectional handles and transparent start/end or decision backgrounds so only the circular or diamond shapes remain visible
- allow the Mermaid preview pane to scroll horizontally so wide diagrams can be inspected without clipping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b026d9b8832fb8035152e27fd600