### PR TITLE
fix: sync git branch id counter

### DIFF
--- a/src/lib/mermaid/diagramDefinitions.ts
+++ b/src/lib/mermaid/diagramDefinitions.ts
@@ -582,25 +582,10 @@ export const diagramDefinitions: Record<MermaidDiagramType, MermaidDiagramDefini
         ],
       },
       {
-        variant: 'branch',
-        label: 'ブランチ作成',
-        description: '新しいブランチを作成して現在のブランチにする',
-        defaultLabel: 'develop',
-        fields: [
-          { key: 'order', label: '表示順序 (order)', type: 'number', placeholder: '例: 1' },
-        ],
-      },
-      {
-        variant: 'checkout',
-        label: 'チェックアウト',
-        description: '既存のブランチへ切り替え',
-        defaultLabel: 'main',
-      },
-      {
         variant: 'merge',
-        label: 'マージ',
-        description: '指定ブランチを現在のブランチへマージ',
-        defaultLabel: 'develop',
+        label: 'マージコミット',
+        description: '他ブランチをマージしたコミットを追加',
+        defaultLabel: 'Merge',
         defaultMetadata: { type: 'NORMAL' },
         fields: [
           { key: 'id', label: 'マージコミットID', type: 'text' },
@@ -628,7 +613,19 @@ export const diagramDefinitions: Record<MermaidDiagramType, MermaidDiagramDefini
         ],
       },
     ],
-    edgeTemplates: [],
+    edgeTemplates: [
+      {
+        variant: 'gitCheckout',
+        label: 'チェックアウト',
+        description: 'ブランチの切り替えを表現するエッジ',
+        defaultMetadata: { command: 'checkout' },
+      },
+      {
+        variant: 'gitMerge',
+        label: 'マージ',
+        description: '他ブランチからのマージを表現するエッジ',
+      },
+    ],
     defaultConfig: { type: 'gitGraph', orientation: 'LR' },
     defaultTemplate: `gitGraph LR:
   commit id: "A"
@@ -650,7 +647,7 @@ export const diagramDefinitions: Record<MermaidDiagramType, MermaidDiagramDefini
         ],
       },
     ],
-    supportsEdges: false,
+    supportsEdges: true,
     createNodeId: () => `git_${createId()}`,
   },
   pie: {

--- a/src/lib/mermaid/types.ts
+++ b/src/lib/mermaid/types.ts
@@ -54,6 +54,14 @@ export interface MermaidSubgraph {
   nodes: string[];
 }
 
+export interface MermaidGitBranch {
+  id: string;
+  name: string;
+  order?: string;
+  sequence?: string;
+  sourceBranchId?: string;
+}
+
 /** React Flowで扱うノード型 */
 export type MermaidNode = Node<MermaidNodeData>;
 /** React Flowで扱うエッジ型 */
@@ -99,4 +107,6 @@ export interface MermaidGraphModel {
   warnings: string[];
   /** フローチャートなどで使用するサブグラフ情報 */
   subgraphs?: MermaidSubgraph[];
+  /** Gitグラフで使用するブランチ情報 */
+  gitBranches?: MermaidGitBranch[];
 }


### PR DESCRIPTION
## Summary
- Added Git branch metadata support to Mermaid types so the graph model can persist branch definitions alongside nodes and edges.
- Reworked the gitGraph diagram definition to focus on commit/merge nodes and new checkout/merge edge templates while enabling edge support.
- Rewrote the gitGraph parser and serializer to hydrate branch lists, create checkout/merge edges, and emit commands based on branches, edges, and node sequences.
- Enhanced the designer UI with branch management in the sidebar, branch-aware node/edge inspectors, sequence handling, and branch overlays.
- Captured a screenshot of the updated designer UI.
- Synced the git branch ID counter with hydrated branch data so newly created branches avoid duplicate identifiers after loading existing diagrams.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d626516250832fa587c9a4513fbe83