### PR TITLE
Ensure Mermaid render uses container for full SVG output

### DIFF
--- a/src/components/preview/MermaidPreview.tsx
+++ b/src/components/preview/MermaidPreview.tsx
@@ -163,7 +163,11 @@ const MermaidPreview: React.FC<MermaidPreviewProps> = ({ content, fileName }) =>
 
       try {
         // mermaidでレンダリング
-        const { svg: renderedSvg } = await mermaid.render(id + '_svg', normalizedContent);
+        const { svg: renderedSvg } = await mermaid.render(
+          id + '_svg',
+          normalizedContent,
+          tempDiv,
+        );
         
         if (renderedSvg) {
           // SVGにパディングを追加して描画範囲を広げる


### PR DESCRIPTION
## Summary
- pass the temporary rendering div to `mermaid.render` so the generated SVG includes full namespace declarations

## Testing
- npm run dev
- Previewed `test_data/mmd/c4.mmd` in the browser and confirmed icons render correctly

------
https://chatgpt.com/codex/tasks/task_e_68d720c59ff8832fb67864043a805b9d