### PR TITLE
Fix OpenStreetMap basemap loading in geo analysis

### DIFF
--- a/src/components/analysis/MultiFileAnalysis.tsx
+++ b/src/components/analysis/MultiFileAnalysis.tsx
@@ -176,11 +176,26 @@ const MultiFileAnalysis: React.FC<MultiFileAnalysisProps> = ({ onClose }) => {
   }, [queryRowsForMap]);
 
   const mapDataSources = useMemo(() => {
-    if (queryRowsForMap.length > 0) {
-      return [{ id: 'queryResult', label: 'クエリ結果', rows: queryRowsForMap, columns: queryColumns }];
+    const sources: { id: string; label: string; rows: any[]; columns: string[] }[] = [];
+
+    fileDataMap.forEach((rows, filePath) => {
+      const fileName = filePath.split('/').pop() || filePath;
+      const label = `ファイル: ${fileName}`;
+      const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+      sources.push({ id: `file:${filePath}`, label, rows, columns });
+    });
+
+    if (combinedData && combinedData.length > 0) {
+      const columns = Object.keys(combinedData[0]);
+      sources.push({ id: 'combinedData', label: '統合データ', rows: combinedData, columns });
     }
-    return [];
-  }, [queryRowsForMap, queryColumns]);
+
+    if (queryRowsForMap.length > 0) {
+      sources.push({ id: 'queryResult', label: 'クエリ結果', rows: queryRowsForMap, columns: queryColumns });
+    }
+
+    return sources;
+  }, [combinedData, fileDataMap, queryColumns, queryRowsForMap]);
 
   // テーマ関連
   const [currentTheme, setCurrentTheme] = useState<string>('light');

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -265,15 +265,8 @@ export const useEditorStore = create<EditorStore>()(
       })),
       mapSettings: {
         dataSource: 'queryResult',
-        latitudeColumn: undefined,
-        longitudeColumn: undefined,
-        geoJsonColumn: undefined,
-        wktColumn: undefined,
-        pathColumn: undefined,
-        polygonColumn: undefined,
-        heightColumn: undefined,
-        categoryColumn: undefined,
-        colorColumn: undefined,
+        activeDataSourceIds: [],
+        layerSettings: {},
         aggregation: 'sum',
         pointRadius: 8,
         columnRadius: 200,
@@ -425,15 +418,8 @@ export const useEditorStore = create<EditorStore>()(
           if (!state.mapSettings) {
             state.mapSettings = {
               dataSource: 'queryResult',
-              latitudeColumn: undefined,
-              longitudeColumn: undefined,
-              geoJsonColumn: undefined,
-              wktColumn: undefined,
-              pathColumn: undefined,
-              polygonColumn: undefined,
-              heightColumn: undefined,
-              categoryColumn: undefined,
-              colorColumn: undefined,
+              activeDataSourceIds: [],
+              layerSettings: {},
               aggregation: 'sum',
               pointRadius: 8,
               columnRadius: 200,
@@ -441,7 +427,17 @@ export const useEditorStore = create<EditorStore>()(
               basemap: 'osm-standard',
               basemapOverlays: { ...DEFAULT_MAP_BASEMAP_OVERLAYS },
             };
-          } else if (!state.mapSettings.basemap) {
+          } else {
+            if (!state.mapSettings.activeDataSourceIds) {
+              state.mapSettings.activeDataSourceIds = state.mapSettings.dataSource
+                ? [state.mapSettings.dataSource]
+                : [];
+            }
+            if (!state.mapSettings.layerSettings) {
+              state.mapSettings.layerSettings = {};
+            }
+          }
+          if (!state.mapSettings.basemap) {
             state.mapSettings.basemap = 'osm-standard';
           }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -132,8 +132,7 @@ export type MapBasemapOverlay = 'roads' | 'railways' | 'terrain';
 
 export type MapBasemapOverlayState = Record<MapBasemapOverlay, boolean>;
 
-export interface MapSettings {
-  dataSource: string;
+export interface MapLayerSettings {
   latitudeColumn?: string;
   longitudeColumn?: string;
   geoJsonColumn?: string;
@@ -143,6 +142,15 @@ export interface MapSettings {
   heightColumn?: string;
   categoryColumn?: string;
   colorColumn?: string;
+}
+
+export interface MapSettings {
+  /**
+   * @deprecated 以前の単一データソース選択用のフィールド。activeDataSourceIds を使用してください。
+   */
+  dataSource?: string;
+  activeDataSourceIds: string[];
+  layerSettings: Record<string, MapLayerSettings>;
   aggregation: MapAggregation;
   pointRadius: number;
   columnRadius: number;


### PR DESCRIPTION
## Summary
- remove the map tab from the single-file analysis flow so geo features stay in multi-file mode
- expose file, combined, and query results as map data sources and add multi-layer configuration support in the geo panel
- extend map settings persistence to track per-layer column choices and initialize defaults for legacy data
- ensure OpenStreetMap tiles load by fetching imagery directly with abort-aware fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7bce2eed8832f8dc410a16b2ef3e7