### PR TITLE
Handle optional shapefile loader dependency

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -30,7 +30,17 @@ const nextConfig: NextConfig = {
         },
       };
     }
-    
+
+    const shapefileWarningPattern = /Critical dependency: the request of a dependency is an expression/;
+    const shapefileModulePattern = /dataPreviewUtils\.ts$/;
+    config.ignoreWarnings = [
+      ...(config.ignoreWarnings ?? []),
+      (warning) =>
+        typeof warning.message === 'string' &&
+        shapefileWarningPattern.test(warning.message) &&
+        shapefileModulePattern.test((warning.module?.resource as string | undefined) ?? ''),
+    ];
+
     return config;
   },
   // TypeScriptの設定


### PR DESCRIPTION
## Summary
- lazily load the shapefile loader so the app can still build when @loaders.gl/shapefile is missing and show a clear fallback error
- silence the webpack critical dependency warning emitted by the optional shapefile import so CI logs stay clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d800947c88832f87cc6c3a86ca28f3