### PR TITLE
Store CodeMirror view reference for markdown features

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -24,6 +24,7 @@ import MarkdownEditorExtension from '@/components/markdown/MarkdownEditorExtensi
 import ExportModal from '@/components/preview/ExportModal';
 import { parseCSV, parseJSON, parseYAML, parseParquet } from '@/lib/dataPreviewUtils';
 import { writeFileContent } from '@/lib/fileSystemUtils';
+import type { EditorRefValue } from '@/types/editor';
 
 const SUPPORTED_CLIPBOARD_FILE_TYPES = new Set<TabData['type']>([
   'text',
@@ -100,10 +101,16 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
   const [isInitialized, setIsInitialized] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [parsedDataForExport, setParsedDataForExport] = useState<any[] | null>(null);
-  const editorRef = useRef(null);
+  const editorRef = useRef<EditorRefValue | null>(null);
   // CodeMirrorのscroller要素をrefで取得
   const codeMirrorScrollerRef = useRef<HTMLDivElement | null>(null);
   const saveShortcutHandlerRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    return () => {
+      editorRef.current = null;
+    };
+  }, []);
   
   // テーマ切替時にCodeMirrorのscroller背景色も同期させる
   // 早期returnの前に配置し、フックの順序が変化しないようにする
@@ -568,6 +575,7 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
               }}
               // CodeMirrorのscroller要素にrefを付与
               onCreateEditor={editor => {
+                editorRef.current = { view: editor };
                 // CodeMirror v6: scroller要素は editor.contentDOM.parentElement
                 if (editor && editor.contentDOM && editor.contentDOM.parentElement) {
                   codeMirrorScrollerRef.current = editor.contentDOM.parentElement as HTMLDivElement;

--- a/src/components/markdown/MarkdownEditorExtension.tsx
+++ b/src/components/markdown/MarkdownEditorExtension.tsx
@@ -23,6 +23,7 @@ import MarkdownHelpDialog from './MarkdownHelpDialog';
 import TableWizard from './TableWizard';
 import { readDirectoryContents } from '@/lib/fileSystemUtils';
 import type { TabData } from '@/types';
+import type { EditorRefValue } from '@/types/editor';
 
 type TableAlignment = 'left' | 'center' | 'right' | null;
 
@@ -255,7 +256,7 @@ const buildImageMarkdown = (fileName: string, altText: string) => {
 
 interface MarkdownEditorExtensionProps {
   tabId: string;
-  editorRef: React.RefObject<any>;
+  editorRef: React.RefObject<EditorRefValue | null>;
 }
 
 /**

--- a/src/hooks/useMarkdownShortcuts.ts
+++ b/src/hooks/useMarkdownShortcuts.ts
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, RefObject } from 'react';
 import { useEditorStore } from '@/store/editorStore';
+import type { EditorRefValue } from '@/types/editor';
 
-const useMarkdownShortcuts = (editorRef: RefObject<any>, tabId: string) => {
+const useMarkdownShortcuts = (editorRef: RefObject<EditorRefValue | null>, tabId: string) => {
   const { tabs, updateTab } = useEditorStore();
   
   const insertMarkdown = useCallback((prefix: string, suffix: string, placeholder: string) => {

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,0 +1,5 @@
+import type { EditorView } from '@codemirror/view';
+
+export interface EditorRefValue {
+  view: EditorView | null;
+}


### PR DESCRIPTION
## Summary
- persist the CodeMirror EditorView on the editor ref and clear it on unmount
- add a shared EditorRefValue type so markdown helpers consistently access the stored view
- update the markdown toolbar helpers to operate on the current EditorView selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8262f3f04832fb1e3d356341a9e7d