### PR TITLE
Add commit comparison diff support and handle FS invalid state errors

### DIFF
--- a/src/components/git/GitDiffView.tsx
+++ b/src/components/git/GitDiffView.tsx
@@ -7,33 +7,75 @@ import { type GitCommitEntry } from '@/store/gitStore';
 interface DiffPayload {
   filePath: string;
   fileName: string;
-  commit: GitCommitEntry | null;
   diff: string;
+  commit: GitCommitEntry | null;
+  baseCommit: GitCommitEntry | null;
+  compareCommit: GitCommitEntry | null;
+  comparisonLabel: string | null;
 }
+
+interface CommitSummaryProps {
+  title: string;
+  commit: GitCommitEntry | null;
+  label?: string | null;
+}
+
+const CommitSummary: React.FC<CommitSummaryProps> = ({ title, commit, label }) => (
+  <div className="rounded border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-slate-800/60">
+    <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</p>
+    {commit ? (
+      <div className="mt-1 space-y-1 text-xs text-gray-600 dark:text-gray-300">
+        <p className="break-words font-medium text-gray-700 dark:text-gray-100">{commit.message}</p>
+        <p className="break-words">{commit.author}</p>
+        <p>{commit.date}</p>
+        <p className="font-mono text-[11px] text-gray-500 dark:text-gray-400">{commit.oid}</p>
+      </div>
+    ) : label ? (
+      <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">{label}</p>
+    ) : (
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">コミット情報がありません。</p>
+    )}
+  </div>
+);
 
 interface GitDiffViewProps {
   tab: TabData;
 }
 
-const defaultCommit: GitCommitEntry = {
-  oid: '',
-  message: '',
-  author: '',
-  date: '',
-};
-
 const GitDiffView: React.FC<GitDiffViewProps> = ({ tab }) => {
   const diffData = useMemo<DiffPayload>(() => {
     try {
-      const parsed = JSON.parse(tab.content) as Partial<DiffPayload>;
+      const parsed = JSON.parse(tab.content) as Partial<
+        DiffPayload & { commit?: GitCommitEntry | null }
+      >;
+      const commit = parsed.commit ?? null;
+      const baseCommit = parsed.baseCommit ?? commit ?? null;
+      const compareCommit = parsed.compareCommit ?? null;
+      let comparisonLabel: string | null = null;
+      if (typeof parsed.comparisonLabel === 'string') {
+        comparisonLabel = parsed.comparisonLabel;
+      } else if (!compareCommit && commit) {
+        comparisonLabel = '作業ツリー';
+      }
       return {
         filePath: parsed.filePath ?? '',
         fileName: parsed.fileName ?? tab.name,
-        commit: parsed.commit ?? defaultCommit,
+        commit,
+        baseCommit,
+        compareCommit,
+        comparisonLabel,
         diff: parsed.diff ?? '',
       };
     } catch {
-      return { filePath: '', fileName: tab.name, commit: defaultCommit, diff: tab.content };
+      return {
+        filePath: '',
+        fileName: tab.name,
+        commit: null,
+        baseCommit: null,
+        compareCommit: null,
+        comparisonLabel: null,
+        diff: tab.content,
+      };
     }
   }, [tab.content, tab.name]);
 
@@ -60,12 +102,10 @@ const GitDiffView: React.FC<GitDiffViewProps> = ({ tab }) => {
       <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
         <h2 className="text-sm font-semibold">{diffData.fileName}</h2>
         <p className="mt-1 break-all text-xs text-gray-500 dark:text-gray-400">{diffData.filePath || 'ファイルパス未指定'}</p>
-        {diffData.commit && diffData.commit.oid && (
-          <div className="mt-2 space-y-1 text-xs text-gray-500 dark:text-gray-400">
-            <p className="font-medium text-gray-600 dark:text-gray-300">{diffData.commit.message}</p>
-            <p>{diffData.commit.author}</p>
-            <p>{diffData.commit.date}</p>
-            <p className="font-mono text-[11px] text-gray-500 dark:text-gray-400">{diffData.commit.oid}</p>
+        {(diffData.baseCommit || diffData.compareCommit || diffData.comparisonLabel) && (
+          <div className="mt-3 grid gap-3 text-xs text-gray-500 dark:text-gray-400 sm:grid-cols-2">
+            <CommitSummary title="比較元" commit={diffData.baseCommit} />
+            <CommitSummary title="比較先" commit={diffData.compareCommit} label={diffData.comparisonLabel} />
           </div>
         )}
       </div>

--- a/src/components/git/GitHistoryView.tsx
+++ b/src/components/git/GitHistoryView.tsx
@@ -36,10 +36,12 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
     commit: GitCommitEntry;
   } | null>(null);
   const [isBusy, setIsBusy] = useState(false);
+  const [selectedCommitOids, setSelectedCommitOids] = useState<string[]>([]);
 
   const menuRef = useRef<HTMLDivElement>(null);
 
   const getDiffAgainstWorkingTree = useGitStore((state) => state.getDiffAgainstWorkingTree);
+  const getDiffBetweenCommits = useGitStore((state) => state.getDiffBetweenCommits);
   const restoreFileToCommit = useGitStore((state) => state.restoreFileToCommit);
 
   const addTab = useEditorStore((state) => state.addTab);
@@ -79,6 +81,10 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
   }, [contextMenu]);
 
   useEffect(() => {
+    setSelectedCommitOids([]);
+  }, [historyData.filePath]);
+
+  useEffect(() => {
     if (!contextMenu || !menuRef.current) {
       return;
     }
@@ -96,6 +102,55 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
     menu.style.top = `${Math.max(0, nextY)}px`;
   }, [contextMenu]);
 
+  const selectedCommits = useMemo(() => {
+    if (selectedCommitOids.length === 0) {
+      return [];
+    }
+    return selectedCommitOids
+      .map((oid) => historyData.commits.find((commit) => commit.oid === oid) || null)
+      .filter((commit): commit is GitCommitEntry => commit !== null);
+  }, [historyData.commits, selectedCommitOids]);
+
+  const selectedPair = useMemo(() => {
+    if (selectedCommitOids.length < 2) {
+      return null;
+    }
+
+    const [firstOid, secondOid] = selectedCommitOids;
+    const firstCommit = historyData.commits.find((commit) => commit.oid === firstOid) || null;
+    const secondCommit = historyData.commits.find((commit) => commit.oid === secondOid) || null;
+    if (!firstCommit || !secondCommit) {
+      return null;
+    }
+
+    const firstIndex = historyData.commits.findIndex((commit) => commit.oid === firstOid);
+    const secondIndex = historyData.commits.findIndex((commit) => commit.oid === secondOid);
+    if (firstIndex === -1 || secondIndex === -1 || firstIndex === secondIndex) {
+      return null;
+    }
+
+    const base = firstIndex > secondIndex ? firstCommit : secondCommit;
+    const target = firstIndex > secondIndex ? secondCommit : firstCommit;
+
+    return { base, target };
+  }, [historyData.commits, selectedCommitOids]);
+
+  const handleToggleCommitSelection = useCallback((commit: GitCommitEntry) => {
+    setSelectedCommitOids((previous) => {
+      if (previous.includes(commit.oid)) {
+        return previous.filter((oid) => oid !== commit.oid);
+      }
+      if (previous.length >= 2) {
+        return [previous[1], commit.oid];
+      }
+      return [...previous, commit.oid];
+    });
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedCommitOids([]);
+  }, []);
+
   const handleShowDiff = useCallback(
     async (commit: GitCommitEntry) => {
       if (!historyData.filePath || isBusy) {
@@ -108,6 +163,9 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
         const payload = {
           filePath: historyData.filePath,
           fileName: historyData.fileName,
+          baseCommit: commit,
+          compareCommit: null as GitCommitEntry | null,
+          comparisonLabel: '作業ツリー',
           commit,
           diff,
         };
@@ -143,8 +201,80 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
         setContextMenu(null);
       }
     },
-    [addTab, getDiffAgainstWorkingTree, getTab, historyData.fileName, historyData.filePath, isBusy, setActiveTabId, updateTab]
+    [
+      addTab,
+      getDiffAgainstWorkingTree,
+      getTab,
+      historyData.fileName,
+      historyData.filePath,
+      isBusy,
+      setActiveTabId,
+      updateTab,
+    ]
   );
+
+  const handleCompareSelected = useCallback(async () => {
+    if (!historyData.filePath || !selectedPair || isBusy) {
+      return;
+    }
+
+    setIsBusy(true);
+    try {
+      const diff = await getDiffBetweenCommits(
+        historyData.filePath,
+        selectedPair.base.oid,
+        selectedPair.target.oid,
+      );
+      const payload = {
+        filePath: historyData.filePath,
+        fileName: historyData.fileName,
+        baseCommit: selectedPair.base,
+        compareCommit: selectedPair.target,
+        comparisonLabel: null as string | null,
+        commit: selectedPair.target,
+        diff,
+      };
+      const serialized = JSON.stringify(payload);
+      const tabId = `git-diff:${historyData.filePath}:${selectedPair.base.oid}:${selectedPair.target.oid}`;
+      const tabName = `${historyData.fileName} Diff (${selectedPair.base.oid.slice(0, 7)}...${selectedPair.target.oid.slice(0, 7)})`;
+      const existing = getTab(tabId);
+      if (existing) {
+        updateTab(tabId, {
+          content: serialized,
+          originalContent: serialized,
+          isDirty: false,
+          type: 'git-diff',
+          isReadOnly: true,
+        });
+        setActiveTabId(tabId);
+      } else {
+        addTab({
+          id: tabId,
+          name: tabName,
+          content: serialized,
+          originalContent: serialized,
+          isDirty: false,
+          type: 'git-diff',
+          isReadOnly: true,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to generate diff between commits:', error);
+      alert(`差分の取得に失敗しました: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsBusy(false);
+    }
+  }, [
+    addTab,
+    getDiffBetweenCommits,
+    getTab,
+    historyData.fileName,
+    historyData.filePath,
+    isBusy,
+    selectedPair,
+    setActiveTabId,
+    updateTab,
+  ]);
 
   const handleRestore = useCallback(
     async (commit: GitCommitEntry) => {
@@ -193,26 +323,83 @@ const GitHistoryView: React.FC<GitHistoryViewProps> = ({ tab }) => {
         {historyData.commits.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400">コミット履歴が存在しません。</p>
         ) : (
-          <ul className="space-y-3">
-            {historyData.commits.map((commit) => (
-              <li
-                key={commit.oid}
-                className="rounded border border-gray-200 bg-white px-3 py-2 shadow-sm dark:border-gray-700 dark:bg-slate-900"
-              >
-                <p className="font-semibold leading-relaxed break-words">{commit.message}</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 break-words">{commit.author}</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{commit.date}</p>
+          <>
+            <div className="mb-4 rounded border border-dashed border-gray-300 bg-gray-50 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-slate-800/60 dark:text-gray-300">
+              <p>差分を確認したいコミットをチェックボックスから2つ選択してください。</p>
+              {selectedCommits.length === 1 && (
+                <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                  選択中: {selectedCommits[0].oid.slice(0, 7)} - {selectedCommits[0].message}
+                </p>
+              )}
+              {selectedPair && (
+                <div className="mt-2 space-y-1 text-[11px] text-gray-500 dark:text-gray-300">
+                  <p>
+                    比較元: <span className="font-mono">{selectedPair.base.oid.slice(0, 7)}</span> - {selectedPair.base.message}
+                  </p>
+                  <p>
+                    比較先: <span className="font-mono">{selectedPair.target.oid.slice(0, 7)}</span> - {selectedPair.target.message}
+                  </p>
+                </div>
+              )}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  onContextMenu={(event) => handleCommitContextMenu(event, commit)}
-                  className="mt-2 block w-full truncate rounded border border-dashed border-blue-400 bg-blue-50 px-2 py-1 text-left font-mono text-xs text-blue-700 hover:border-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200"
-                  title="右クリックでアクションを表示"
+                  onClick={handleCompareSelected}
+                  disabled={!selectedPair || isBusy}
+                  className="rounded bg-blue-600 px-3 py-1 text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-200 dark:bg-blue-500 dark:hover:bg-blue-600"
                 >
-                  {commit.oid}
+                  選択したコミットの差分を表示
                 </button>
-              </li>
-            ))}
-          </ul>
+                <button
+                  type="button"
+                  onClick={handleClearSelection}
+                  disabled={selectedCommitOids.length === 0 || isBusy}
+                  className="rounded border border-gray-300 px-3 py-1 text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+                >
+                  選択をクリア
+                </button>
+              </div>
+            </div>
+            <ul className="space-y-3">
+              {historyData.commits.map((commit) => {
+                const isSelected = selectedCommitOids.includes(commit.oid);
+                return (
+                  <li
+                    key={commit.oid}
+                    className={`rounded border px-3 py-2 shadow-sm transition dark:border-gray-700 dark:bg-slate-900 ${
+                      isSelected
+                        ? 'border-blue-400 bg-blue-50/70 dark:border-blue-500 dark:bg-blue-950/40'
+                        : 'border-gray-200 bg-white'
+                    }`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => handleToggleCommitSelection(commit)}
+                        disabled={isBusy}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        aria-label={`${commit.oid} を比較対象に選択`}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="break-words font-semibold leading-relaxed">{commit.message}</p>
+                        <p className="break-words text-xs text-gray-500 dark:text-gray-400">{commit.author}</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">{commit.date}</p>
+                        <button
+                          type="button"
+                          onContextMenu={(event) => handleCommitContextMenu(event, commit)}
+                          className="mt-2 block w-full truncate rounded border border-dashed border-blue-400 bg-blue-50 px-2 py-1 text-left font-mono text-xs text-blue-700 hover:border-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200"
+                          title="右クリックでアクションを表示"
+                        >
+                          {commit.oid}
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
         )}
       </div>
       {contextMenu && (


### PR DESCRIPTION
## Summary
- allow selecting two commits from the git history modal to open a comparison diff tab
- enhance the diff viewer with clearer metadata for the compared revisions
- add a store helper for commit-to-commit diffs and retry invalid state FS errors encountered after cloning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d2b54f0c832fb3c7c0cd1dce850c