### PR TITLE
Add Git pull action and show loading overlay during async work

### DIFF
--- a/src/components/git/GitPanel.tsx
+++ b/src/components/git/GitPanel.tsx
@@ -5,6 +5,7 @@ import {
   IoGitBranchOutline,
   IoGitCommitOutline,
   IoGitCompareOutline,
+  IoCloudDownloadOutline,
   IoRefresh,
   IoWarningOutline,
   IoCheckmarkCircle,
@@ -47,6 +48,7 @@ const GitPanel: React.FC = () => {
     commit,
     checkoutBranch,
     createBranch,
+    pullRepository,
   } = useGitStore();
   const [commitMessage, setCommitMessage] = useState('');
   const [newBranchName, setNewBranchName] = useState('');
@@ -83,6 +85,15 @@ const GitPanel: React.FC = () => {
           <span className="font-semibold text-sm">ソース管理</span>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => pullRepository()}
+            title="リモートから最新を取得"
+            disabled={!repoInitialized || loading}
+            aria-label="Pull Latest Changes"
+          >
+            <IoCloudDownloadOutline size={18} />
+          </button>
           <button
             className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
             onClick={() => refreshRepository()}

--- a/src/components/layout/LoadingOverlay.tsx
+++ b/src/components/layout/LoadingOverlay.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import { IoReloadOutline } from 'react-icons/io5';
+
+interface LoadingOverlayProps {
+  visible: boolean;
+  message?: string;
+}
+
+const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ visible, message }) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div className="flex flex-col items-center gap-3 rounded-lg border border-gray-200 bg-white px-6 py-5 text-sm shadow-lg dark:border-gray-700 dark:bg-gray-900/95">
+        <IoReloadOutline className="h-8 w-8 animate-spin text-blue-600" aria-hidden="true" />
+        <p className="text-gray-700 dark:text-gray-200">{message ?? '処理を実行しています…'}</p>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -20,6 +20,7 @@ import { getMermaidTemplate } from '@/lib/mermaid/diagramDefinitions';
 import { TabData } from '@/types';
 import type { MermaidDiagramType } from '@/lib/mermaid/types';
 import GitCloneDialog from '@/components/git/GitCloneDialog';
+import LoadingOverlay from '@/components/layout/LoadingOverlay';
 
 const MainLayout = () => {
   const {
@@ -55,6 +56,7 @@ const MainLayout = () => {
   } | null>(null);
 
   const cloneRepository = useGitStore((state) => state.cloneRepository);
+  const gitLoading = useGitStore((state) => state.loading);
 
   const activeTab = activeTabId ? tabs.get(activeTabId) : null;
   const activeTabViewMode = activeTabId ? getViewMode(activeTabId) : 'editor';
@@ -281,6 +283,16 @@ const MainLayout = () => {
     [addTab, addTempTab, pendingMermaidFile],
   );
 
+  const loadingMessage = useMemo(() => {
+    if (isCloningRepo) {
+      return 'Gitリポジトリをクローンしています…';
+    }
+    if (gitLoading) {
+      return 'Gitリポジトリを更新しています…';
+    }
+    return undefined;
+  }, [gitLoading, isCloningRepo]);
+
   const canToggleViewMode = useMemo(() => {
     return Boolean(activeTab && (fileTypeFlags.isPreviewableSpecialType || fileTypeFlags.isDataPreviewable));
   }, [activeTab, fileTypeFlags.isDataPreviewable, fileTypeFlags.isPreviewableSpecialType]);
@@ -490,6 +502,8 @@ const MainLayout = () => {
           errorMessage={gitCloneError ?? undefined}
         />
       )}
+
+      <LoadingOverlay visible={gitLoading || isCloningRepo} message={loadingMessage} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a reusable loading overlay component so long running Git actions display feedback
- implement a git pull helper in the Git store and surface it from the Git panel toolbar
- reuse the cached HTTP client for cloning and show the overlay during cloning/pull operations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d679412c832fa38366d389301972