### PR TITLE
Enable in-app PDF previews

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,12 @@ const nextConfig: NextConfig = {
       stream: false,
     };
 
+    // PDF.js workerを静的アセットとして扱う
+    config.module.rules.push({
+      test: /pdf\.worker\.(min\.)?m?js$/,
+      type: 'asset/resource',
+    });
+
     // Mermaidの最適化設定
     if (!isServer) {
       config.optimization = {

--- a/src/components/preview/PdfPreview.tsx
+++ b/src/components/preview/PdfPreview.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * PdfPreview.tsx
  * PDFファイルのプレビュー表示Reactコンポーネント。
@@ -6,8 +8,15 @@
  * - ページ送り・ズーム・ダウンロード
  * - ダークモード対応
  */
+
 import React, { useRef, useEffect, useState } from 'react';
-import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
+import {
+  GlobalWorkerOptions,
+  getDocument,
+  type DocumentInitParameters,
+  type PDFDocumentLoadingTask,
+} from 'pdfjs-dist';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs';
 
 interface PdfPreviewProps {
   fileUrl: string;
@@ -17,21 +26,46 @@ interface PdfPreviewProps {
 const PdfPreview: React.FC<PdfPreviewProps> = ({ fileUrl }) => {
   const viewerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    GlobalWorkerOptions.workerSrc = workerSrc;
+  }, []);
 
   useEffect(() => {
     if (!fileUrl) return;
     let isCancelled = false;
-    // PDF.js workerのパス設定（CDN利用、Next.js対応）
-    GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+    let loadingTask: PDFDocumentLoadingTask | null = null;
 
     const renderPDF = async () => {
       if (!viewerRef.current) return;
       setError(null);
-      const loadingTask = getDocument(fileUrl);
+      setIsLoading(true);
+      let params: string | DocumentInitParameters = fileUrl;
+
+      if (fileUrl.startsWith('data:application/pdf;base64,')) {
+        try {
+          const [, base64] = fileUrl.split(',');
+          if (!base64) {
+            throw new Error('base64 data not found');
+          }
+          params = { data: Uint8Array.from(atob(base64), (char: string) => char.charCodeAt(0)) };
+        } catch (conversionError) {
+          console.error('PDFデータの変換に失敗しました:', conversionError);
+          setError('PDFデータの読み込みに失敗しました。');
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      loadingTask = getDocument(params);
 
       try {
         const pdf = await loadingTask.promise;
-        if (isCancelled || !viewerRef.current) return;
+        if (isCancelled || !viewerRef.current) {
+          await loadingTask.destroy();
+          return;
+        }
 
         const page = await pdf.getPage(1); // 1ページ目のみ表示
         const viewport = page.getViewport({ scale: 1.5 });
@@ -48,14 +82,19 @@ const PdfPreview: React.FC<PdfPreviewProps> = ({ fileUrl }) => {
         const context = canvas.getContext('2d');
         if (!context) {
           setError('PDFの描画に失敗しました。');
+          await loadingTask.destroy();
           return;
         }
 
         await page.render({ canvasContext: context, viewport, canvas }).promise;
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
       } catch (err) {
         console.error('PDFプレビューの読み込みに失敗しました:', err);
         if (!isCancelled) {
           setError('PDFの読み込みに失敗しました。');
+          setIsLoading(false);
         }
       }
     };
@@ -63,6 +102,13 @@ const PdfPreview: React.FC<PdfPreviewProps> = ({ fileUrl }) => {
 
     return () => {
       isCancelled = true;
+      setIsLoading(false);
+      if (loadingTask) {
+        loadingTask.destroy();
+      }
+      if (viewerRef.current) {
+        viewerRef.current.innerHTML = '';
+      }
     };
   }, [fileUrl]);
 
@@ -72,8 +118,15 @@ const PdfPreview: React.FC<PdfPreviewProps> = ({ fileUrl }) => {
       {error && (
         <p className="text-red-500 mb-2">{error}</p>
       )}
-      <div ref={viewerRef} className="border rounded min-h-[400px] bg-gray-50 flex items-center justify-center">
-        {/* CanvasにPDFが描画される */}
+      <div className="relative border rounded min-h-[400px] bg-gray-50 dark:bg-gray-900 flex items-center justify-center overflow-auto">
+        <div ref={viewerRef} className="w-full flex items-center justify-center p-2">
+          {/* CanvasにPDFが描画される */}
+        </div>
+        {isLoading && !error && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white/70 dark:bg-gray-900/70">
+            <p className="text-sm text-gray-600 dark:text-gray-300">PDFを読み込み中です…</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/types/pdfjs-worker.d.ts
+++ b/types/pdfjs-worker.d.ts
@@ -1,0 +1,4 @@
+declare module 'pdfjs-dist/build/pdf.worker.min.mjs' {
+  const workerSrc: string;
+  export default workerSrc;
+}


### PR DESCRIPTION
## Summary
- convert the PDF preview component into a client-side renderer backed by the bundled pdf.js worker
- add loading/error handling for object URLs and base64 encoded PDFs so the first page renders reliably
- declare the pdf.js worker module for TypeScript consumers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9ea1e6d24832f91f130125ed76192