### PR TITLE
Add AI-assisted Mermaid generation workflow

### DIFF
--- a/src/app/api/llm/mermaid/route.ts
+++ b/src/app/api/llm/mermaid/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { diagramDefinitions } from '@/lib/mermaid/diagramDefinitions';
+import type { MermaidDiagramType } from '@/lib/mermaid/types';
+import { callMermaidGenerationModel } from '@/lib/llm/mermaidGenerator';
+
+interface MermaidApiRequestBody {
+  prompt?: unknown;
+  diagramType?: unknown;
+  existingCode?: unknown;
+}
+
+const DIAGRAM_TYPES = new Set(Object.keys(diagramDefinitions) as MermaidDiagramType[]);
+
+function normalizePrompt(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function normalizeDiagramType(value: unknown): MermaidDiagramType {
+  if (typeof value !== 'string') {
+    return 'flowchart';
+  }
+  const trimmed = value.trim() as MermaidDiagramType;
+  return DIAGRAM_TYPES.has(trimmed) ? trimmed : 'flowchart';
+}
+
+function normalizeExistingCode(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export async function POST(request: Request) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'OPENAI_API_KEY が設定されていません。' }, { status: 500 });
+    }
+
+    const body: MermaidApiRequestBody = await request.json();
+    const prompt = normalizePrompt(body.prompt);
+    if (!prompt) {
+      return NextResponse.json({ error: '自然言語で説明を入力してください。' }, { status: 400 });
+    }
+
+    const diagramType = normalizeDiagramType(body.diagramType);
+    const existingCode = normalizeExistingCode(body.existingCode);
+
+    const result = await callMermaidGenerationModel(apiKey, {
+      prompt,
+      diagramType,
+      existingCode,
+    });
+
+    return NextResponse.json({
+      diagramType: result.diagramType,
+      mermaid: result.mermaidCode,
+      summary: result.summary ?? null,
+    });
+  } catch (error) {
+    console.error('Mermaid generation API error:', error);
+    const message = error instanceof Error ? error.message : 'Mermaidコードの生成中にエラーが発生しました。';
+    const status = /OPENAI_API_KEY/.test(message) ? 500 : 502;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -640,7 +640,12 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
                 <HtmlPreview tabId={tabId} />
               </div>
             ) : isMermaidTab ? (
-              <MermaidPreview content={currentTab.content} fileName={currentTab.name} />
+              <MermaidPreview
+                content={currentTab.content}
+                fileName={currentTab.name}
+                tabId={tabId}
+                enableAiActions
+              />
             ) : (
               <div className="h-full">
                 <DataPreview tabId={tabId} />

--- a/src/components/explorer/FileExplorer.tsx
+++ b/src/components/explorer/FileExplorer.tsx
@@ -561,10 +561,10 @@ const FileExplorer = () => {
   }, []);
 
   const handleMermaidTemplateConfirm = useCallback(
-    async (diagramType: MermaidDiagramType) => {
+    async (diagramType: MermaidDiagramType, generatedCode?: string) => {
       if (!pendingMermaidFile) return;
 
-      const template = getMermaidTemplate(diagramType);
+      const template = generatedCode ?? getMermaidTemplate(diagramType);
 
       try {
         if (pendingMermaidFile.mode === 'newFile') {
@@ -861,6 +861,8 @@ const FileExplorer = () => {
       {showMermaidTemplateDialog && pendingMermaidFile && (
         <MermaidTemplateDialog
           isOpen={showMermaidTemplateDialog}
+          fileName={pendingMermaidFile.fileName}
+          historyKey={pendingMermaidFile.fileName}
           onCancel={handleMermaidTemplateCancel}
           onConfirm={handleMermaidTemplateConfirm}
         />

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -239,10 +239,10 @@ const MainLayout = () => {
   }, []);
 
   const handleMermaidTemplateConfirm = useCallback(
-    async (diagramType: MermaidDiagramType) => {
+    async (diagramType: MermaidDiagramType, generatedCode?: string) => {
       if (!pendingMermaidFile) return;
 
-      const template = getMermaidTemplate(diagramType);
+      const template = generatedCode ?? getMermaidTemplate(diagramType);
 
       try {
         if (pendingMermaidFile.directoryHandle) {
@@ -488,6 +488,8 @@ const MainLayout = () => {
       {showMermaidTemplateDialog && pendingMermaidFile && (
         <MermaidTemplateDialog
           isOpen={showMermaidTemplateDialog}
+          fileName={pendingMermaidFile.fileName}
+          historyKey={pendingMermaidFile.fileName}
           onCancel={handleMermaidTemplateCancel}
           onConfirm={handleMermaidTemplateConfirm}
         />

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -149,7 +149,12 @@ const Workspace: React.FC<WorkspaceProps> = ({
           {isMarkdown ? (
             <MarkdownPreview tabId={activeTabId} />
           ) : isMermaid ? (
-            <MermaidPreview content={activeTab.content} fileName={activeTab.name} />
+            <MermaidPreview
+              content={activeTab.content}
+              fileName={activeTab.name}
+              tabId={activeTabId}
+              enableAiActions={Boolean(activeTabId && isMermaid)}
+            />
           ) : isHtml ? (
             <HtmlPreview tabId={activeTabId} />
           ) : (
@@ -195,7 +200,12 @@ const Workspace: React.FC<WorkspaceProps> = ({
           {isMarkdown ? (
             <MarkdownPreview tabId={activeTabId} onScroll={handlePreviewScroll} />
           ) : isMermaid ? (
-            <MermaidPreview content={activeTab.content} fileName={activeTab.name} />
+            <MermaidPreview
+              content={activeTab.content}
+              fileName={activeTab.name}
+              tabId={activeTabId}
+              enableAiActions={Boolean(activeTabId && isMermaid)}
+            />
           ) : isHtml ? (
             <HtmlPreview tabId={activeTabId} onScroll={handlePreviewScroll} />
           ) : (

--- a/src/components/mermaid/MermaidCodePreview.tsx
+++ b/src/components/mermaid/MermaidCodePreview.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { initializeMermaid } from '@/lib/mermaid/mermaidClient';
+import { normalizeMermaidSource } from '@/lib/mermaid/normalize';
+
+interface MermaidCodePreviewProps {
+  code: string;
+  className?: string;
+}
+
+const MermaidCodePreview: React.FC<MermaidCodePreviewProps> = ({ code, className }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isRendering, setIsRendering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const target = containerRef.current;
+    if (!target) {
+      return;
+    }
+
+    let canceled = false;
+
+    const render = async () => {
+      const normalized = normalizeMermaidSource(code);
+      if (!normalized) {
+        target.innerHTML = '';
+        setError('プレビューするMermaidコードがありません。');
+        return;
+      }
+
+      setIsRendering(true);
+      setError(null);
+
+      try {
+        const mermaid = await initializeMermaid();
+        if (!mermaid) {
+          throw new Error('Mermaidの初期化に失敗しました。');
+        }
+
+        const id = `mermaid-inline-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const { svg } = await mermaid.render(id, normalized);
+        if (canceled) {
+          return;
+        }
+        target.innerHTML = svg ?? '';
+      } catch (err) {
+        if (canceled) {
+          return;
+        }
+        console.error('Mermaid inline preview error:', err);
+        const message = err instanceof Error ? err.message : 'プレビューの生成に失敗しました。';
+        setError(message);
+        target.innerHTML = '';
+      } finally {
+        if (!canceled) {
+          setIsRendering(false);
+        }
+      }
+    };
+
+    render();
+
+    return () => {
+      canceled = true;
+      target.innerHTML = '';
+    };
+  }, [code]);
+
+  return (
+    <div className={className}>
+      {isRendering && (
+        <div className="text-sm text-gray-500 dark:text-gray-400">AIプレビューをレンダリング中…</div>
+      )}
+      {!isRendering && error && (
+        <div className="text-sm text-red-500 dark:text-red-400">{error}</div>
+      )}
+      {!error && (
+        <div
+          ref={containerRef}
+          className="mermaid-output text-left"
+          aria-label="Mermaidプレビュー"
+        />
+      )}
+    </div>
+  );
+};
+
+export default MermaidCodePreview;

--- a/src/components/mermaid/MermaidDesigner.tsx
+++ b/src/components/mermaid/MermaidDesigner.tsx
@@ -3085,7 +3085,7 @@ const MermaidDesigner: React.FC<MermaidDesignerProps> = ({ tabId, fileName, cont
             </div>
           )}
           <div className="border border-gray-200 dark:border-gray-800 rounded overflow-hidden">
-            <MermaidPreview content={generatedCode} fileName={fileName} />
+            <MermaidPreview content={generatedCode} fileName={fileName} enableAiActions={false} />
           </div>
         </div>
       </aside>

--- a/src/components/modals/MermaidTemplateDialog.tsx
+++ b/src/components/modals/MermaidTemplateDialog.tsx
@@ -1,24 +1,41 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { IoCloseOutline } from 'react-icons/io5';
 import { diagramDefinitions, diagramList } from '@/lib/mermaid/diagramDefinitions';
 import type { MermaidDiagramType } from '@/lib/mermaid/types';
+import MermaidCodePreview from '@/components/mermaid/MermaidCodePreview';
+import { requestMermaidGeneration } from '@/lib/llm/mermaidGenerator';
+import { createId } from '@/lib/utils/id';
+import { useEditorStore } from '@/store/editorStore';
+import type { MermaidGenerationHistoryEntry } from '@/types';
+
+const EMPTY_HISTORY: MermaidGenerationHistoryEntry[] = [];
 
 interface MermaidTemplateDialogProps {
   isOpen: boolean;
+  fileName: string;
   initialType?: MermaidDiagramType;
+  historyKey?: string;
   onCancel: () => void;
-  onConfirm: (diagramType: MermaidDiagramType) => void;
+  onConfirm: (diagramType: MermaidDiagramType, generatedCode?: string) => void;
 }
 
 const MermaidTemplateDialog: React.FC<MermaidTemplateDialogProps> = ({
   isOpen,
+  fileName,
   initialType = 'flowchart',
+  historyKey,
   onCancel,
   onConfirm,
 }) => {
   const [selectedType, setSelectedType] = useState<MermaidDiagramType>(initialType);
+  const [prompt, setPrompt] = useState('');
+  const [generatedCode, setGeneratedCode] = useState('');
+  const [summary, setSummary] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [selectedHistoryId, setSelectedHistoryId] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -26,17 +43,113 @@ const MermaidTemplateDialog: React.FC<MermaidTemplateDialogProps> = ({
     }
   }, [initialType, isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setPrompt('');
+      setGeneratedCode('');
+      setSummary('');
+      setErrorMessage(null);
+      setSelectedHistoryId(null);
+    }
+  }, [isOpen]);
+
   const definition = useMemo(() => diagramDefinitions[selectedType], [selectedType]);
+  const effectiveHistoryKey = useMemo(() => historyKey ?? fileName, [historyKey, fileName]);
+
+  const mermaidHistory = useEditorStore(
+    (state) => state.mermaidGenerationHistory[effectiveHistoryKey] ?? EMPTY_HISTORY,
+  );
+  const addHistoryEntry = useEditorStore((state) => state.addMermaidGenerationEntry);
+  const updateHistoryEntry = useEditorStore((state) => state.updateMermaidGenerationEntry);
+
+  const selectedHistoryEntry = useMemo<MermaidGenerationHistoryEntry | null>(() => {
+    if (!selectedHistoryId) return null;
+    return mermaidHistory.find((entry) => entry.id === selectedHistoryId) ?? null;
+  }, [mermaidHistory, selectedHistoryId]);
+
+  useEffect(() => {
+    if (selectedHistoryEntry) {
+      setSelectedType(selectedHistoryEntry.diagramType);
+      setPrompt(selectedHistoryEntry.prompt);
+      setGeneratedCode(selectedHistoryEntry.mermaidCode);
+      setSummary(selectedHistoryEntry.summary ?? '');
+      setErrorMessage(null);
+    }
+  }, [selectedHistoryEntry]);
+
+  const handleGenerate = useCallback(async () => {
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) {
+      setErrorMessage('生成する内容を入力してください。');
+      return;
+    }
+
+    setIsGenerating(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await requestMermaidGeneration({
+        prompt: trimmedPrompt,
+        diagramType: selectedType,
+      });
+      const code = response.mermaidCode;
+      if (!code) {
+        throw new Error('生成結果が空でした。');
+      }
+
+      setGeneratedCode(code);
+      setSummary(response.summary ?? '');
+
+      const entry: MermaidGenerationHistoryEntry = {
+        id: createId('mermaid_ai'),
+        diagramType: response.diagramType ?? selectedType,
+        prompt: trimmedPrompt,
+        mermaidCode: code,
+        summary: response.summary ?? '',
+        createdAt: new Date().toISOString(),
+      };
+      addHistoryEntry(effectiveHistoryKey, entry);
+      setSelectedHistoryId(entry.id);
+    } catch (error) {
+      console.error('Mermaid generation error:', error);
+      const message = error instanceof Error ? error.message : 'AI生成に失敗しました。';
+      setErrorMessage(message);
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [addHistoryEntry, effectiveHistoryKey, prompt, selectedType]);
+
+  const handleApplyGeneratedCode = useCallback(() => {
+    if (!generatedCode) {
+      setErrorMessage('AI生成されたコードがありません。');
+      return;
+    }
+    onConfirm(selectedType, generatedCode);
+    if (selectedHistoryId) {
+      updateHistoryEntry(effectiveHistoryKey, selectedHistoryId, {
+        appliedAt: new Date().toISOString(),
+      });
+    }
+  }, [effectiveHistoryKey, generatedCode, onConfirm, selectedHistoryId, selectedType, updateHistoryEntry]);
+
+  const handleConfirmTemplate = useCallback(() => {
+    onConfirm(selectedType);
+  }, [onConfirm, selectedType]);
 
   if (!isOpen) {
     return null;
   }
 
+  const hasHistory = mermaidHistory.length > 0;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg w-[30rem] max-w-full">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg w-[36rem] max-w-full">
         <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-gray-700">
-          <h3 className="text-lg font-medium">Mermaid テンプレートを選択</h3>
+          <div>
+            <h3 className="text-lg font-medium">Mermaid テンプレートを選択</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 break-all">{fileName}</p>
+          </div>
           <button
             type="button"
             className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
@@ -47,7 +160,7 @@ const MermaidTemplateDialog: React.FC<MermaidTemplateDialogProps> = ({
           </button>
         </div>
 
-        <div className="p-4 space-y-4">
+        <div className="p-4 space-y-5">
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               図の種類
@@ -63,34 +176,134 @@ const MermaidTemplateDialog: React.FC<MermaidTemplateDialogProps> = ({
                 </option>
               ))}
             </select>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-              {definition.description}
-            </p>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{definition.description}</p>
+          </div>
+
+          <div className="space-y-3 border border-gray-200 dark:border-gray-700 rounded-md p-4 bg-gray-50 dark:bg-gray-900">
+            <div className="flex flex-col gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+                  自然言語説明
+                </label>
+                <textarea
+                  className="w-full h-24 border border-gray-300 dark:border-gray-600 rounded-md p-2 text-sm bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  placeholder="例: 部署間の承認フローをフローチャートで表現し、主要な意思決定ポイントを強調"
+                />
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={isGenerating}
+                  className="px-4 py-2 text-sm rounded-md bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
+                >
+                  {isGenerating ? '生成中…' : 'AI生成'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setGeneratedCode('');
+                    setSummary('');
+                    setSelectedHistoryId(null);
+                    setErrorMessage(null);
+                  }}
+                  disabled={!generatedCode && !summary}
+                  className="px-4 py-2 text-sm rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-60 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                >
+                  リセット
+                </button>
+              </div>
+
+              {errorMessage && <p className="text-xs text-red-500">{errorMessage}</p>}
+            </div>
+
+            {hasHistory && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">生成履歴</label>
+                <select
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md p-2 text-sm bg-white dark:bg-gray-800"
+                  value={selectedHistoryId ?? ''}
+                  onChange={(event) => setSelectedHistoryId(event.target.value || null)}
+                >
+                  <option value="">履歴を選択…</option>
+                  {mermaidHistory.map((entry) => {
+                    const createdAt = new Date(entry.createdAt);
+                    const timestamp = Number.isNaN(createdAt.getTime())
+                      ? entry.createdAt
+                      : createdAt.toLocaleString();
+                    return (
+                      <option key={entry.id} value={entry.id}>
+                        {`${timestamp}｜${entry.diagramType}`}
+                      </option>
+                    );
+                  })}
+                </select>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  過去のプロンプトと生成結果を呼び出して再利用できます。
+                </p>
+              </div>
+            )}
+
+            {summary && (
+              <div className="text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md p-3">
+                {summary}
+              </div>
+            )}
+
+            {generatedCode && (
+              <div className="space-y-3">
+                <div className="border border-gray-200 dark:border-gray-700 rounded-md p-3 bg-white dark:bg-gray-900">
+                  <MermaidCodePreview code={generatedCode} />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">生成されたMermaidコード</label>
+                  <pre className="w-full max-h-48 overflow-auto border border-gray-200 dark:border-gray-700 rounded-md bg-gray-50 dark:bg-gray-900 p-3 text-xs whitespace-pre-wrap">
+                    {generatedCode}
+                  </pre>
+                </div>
+              </div>
+            )}
           </div>
 
           <div>
-            <p className="text-xs text-gray-500 mb-1">挿入されるテンプレート</p>
+            <p className="text-xs text-gray-500 mb-1">テンプレートのプレビュー</p>
             <pre className="bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md p-3 text-xs overflow-x-auto whitespace-pre">
               {definition.defaultTemplate}
             </pre>
           </div>
         </div>
 
-        <div className="flex justify-end gap-2 p-4 border-t border-gray-200 dark:border-gray-700">
-          <button
-            type="button"
-            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600"
-            onClick={onCancel}
-          >
-            キャンセル
-          </button>
-          <button
-            type="button"
-            className="px-4 py-2 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700"
-            onClick={() => onConfirm(selectedType)}
-          >
-            作成
-          </button>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 border-t border-gray-200 dark:border-gray-700">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            AI生成結果を採用するか、既定のテンプレートを使用してファイルを作成できます。
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600"
+              onClick={onCancel}
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700"
+              onClick={handleConfirmTemplate}
+            >
+              テンプレートで作成
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 text-sm text-white bg-purple-600 rounded-md hover:bg-purple-700 disabled:opacity-60"
+              onClick={handleApplyGeneratedCode}
+              disabled={!generatedCode}
+            >
+              AI結果で作成
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -457,7 +457,11 @@ const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(({ tabI
                   if (match?.[1] === 'mermaid') {
                     const fileName = tabs.get(tabId)?.name || 'mermaid-diagram.mmd';
                     // MermaidPreviewを描画
-                    return <div className="my-4"><MermaidPreview content={trimmedCode} fileName={fileName} /></div>;
+                    return (
+                      <div className="my-4">
+                        <MermaidPreview content={trimmedCode} fileName={fileName} enableAiActions={false} />
+                      </div>
+                    );
                   }
                   // 通常配色（枠線なし）
                   const preClass = 'rounded px-5 py-3 my-4 bg-gray-100 text-gray-900 whitespace-pre-line';

--- a/src/lib/llm/mermaidGenerator.ts
+++ b/src/lib/llm/mermaidGenerator.ts
@@ -1,0 +1,203 @@
+import type { MermaidDiagramType } from '@/lib/mermaid/types';
+import type { ChatCompletionMessage } from './workflowPrompt';
+
+export interface MermaidGenerationRequest {
+  prompt: string;
+  diagramType: MermaidDiagramType;
+  existingCode?: string;
+}
+
+export interface MermaidGenerationResponse {
+  diagramType: MermaidDiagramType;
+  mermaidCode: string;
+  summary?: string;
+}
+
+interface MermaidModelPayload {
+  diagramType: MermaidDiagramType;
+  description: string;
+  existingCode?: string;
+}
+
+const OPENAI_CHAT_COMPLETION_URL = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = 'gpt-4o-mini';
+
+const MERMAID_SYSTEM_PROMPT = [
+  'You are a senior technical writer who translates requirements into valid Mermaid diagrams.',
+  'Always return JSON with the following keys: diagramType (string), mermaid (string), and summary (string).',
+  'The "mermaid" value must contain only the Mermaid source code for the requested diagram and must be valid for Mermaid v11.',
+  'Keep the summary concise (max 120 characters) and written in Japanese.',
+  'If existing code is provided, update or extend it instead of ignoring it.',
+].join('\n');
+
+function buildUserContent(payload: MermaidModelPayload): string {
+  const lines = [
+    `Mermaid diagram type: ${payload.diagramType}`,
+    'Natural language description:',
+    payload.description.trim(),
+  ];
+
+  if (payload.existingCode) {
+    lines.push('\nExisting Mermaid code to refine:');
+    lines.push('```mermaid');
+    lines.push(payload.existingCode.trim());
+    lines.push('```');
+  }
+
+  lines.push('\nConstraints:');
+  lines.push('- Produce a single JSON object with keys diagramType, mermaid, summary.');
+  lines.push('- The mermaid field must be valid Mermaid syntax without markdown fences.');
+  lines.push('- Align with the requested diagram type and keep node names readable.');
+
+  return lines.join('\n');
+}
+
+export function buildMermaidGenerationMessages(payload: MermaidGenerationRequest): ChatCompletionMessage[] {
+  return [
+    { role: 'system', content: MERMAID_SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content: buildUserContent({
+        diagramType: payload.diagramType,
+        description: payload.prompt,
+        existingCode: payload.existingCode,
+      }),
+    },
+  ];
+}
+
+function extractJsonFromResponse(raw: string): any {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) {
+    throw new Error('モデル応答が空でした。');
+  }
+
+  const jsonFence = trimmed.match(/```json\s*([\s\S]*?)```/i);
+  if (jsonFence && jsonFence[1]) {
+    try {
+      return JSON.parse(jsonFence[1]);
+    } catch (error) {
+      throw new Error('モデル応答(JSON)の解析に失敗しました。');
+    }
+  }
+
+  const genericFence = trimmed.match(/```[a-z]*\s*([\s\S]*?)```/i);
+  if (genericFence && genericFence[1]) {
+    try {
+      return JSON.parse(genericFence[1]);
+    } catch (error) {
+      throw new Error('モデル応答(JSON)の解析に失敗しました。');
+    }
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error('モデル応答(JSON)の解析に失敗しました。');
+  }
+}
+
+function normalizeDiagramType(value: unknown, fallback: MermaidDiagramType): MermaidDiagramType {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const normalized = value.trim() as MermaidDiagramType;
+  return normalized || fallback;
+}
+
+function parseMermaidModelResponse(
+  payload: MermaidGenerationRequest,
+  rawContent: string,
+): MermaidGenerationResponse {
+  const data = extractJsonFromResponse(rawContent);
+  const mermaidCode = typeof data?.mermaid === 'string' ? data.mermaid.trim() : '';
+  if (!mermaidCode) {
+    throw new Error('AI生成の結果からMermaidコードを取得できませんでした。');
+  }
+
+  const diagramType = normalizeDiagramType(data?.diagramType, payload.diagramType);
+  const summary = typeof data?.summary === 'string' ? data.summary.trim() : undefined;
+
+  return {
+    diagramType,
+    mermaidCode,
+    summary,
+  };
+}
+
+export async function callMermaidGenerationModel(
+  apiKey: string,
+  payload: MermaidGenerationRequest,
+): Promise<MermaidGenerationResponse> {
+  const response = await fetch(OPENAI_CHAT_COMPLETION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: DEFAULT_MODEL,
+      temperature: 0.3,
+      messages: buildMermaidGenerationMessages(payload),
+    }),
+  });
+
+  if (!response.ok) {
+    let message = 'Mermaidコードの生成に失敗しました。';
+    try {
+      const errorPayload = await response.json();
+      message = errorPayload?.error?.message || message;
+    } catch {
+      // ignore JSON parse errors
+    }
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const content: string | undefined = data?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error('モデルから有効な応答を取得できませんでした。');
+  }
+
+  return parseMermaidModelResponse(payload, content);
+}
+
+export async function requestMermaidGeneration(
+  payload: MermaidGenerationRequest,
+): Promise<MermaidGenerationResponse> {
+  const response = await fetch('/api/llm/mermaid', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `Mermaidコードの生成に失敗しました。（${response.status}）`;
+    try {
+      const errorPayload = await response.json();
+      if (errorPayload && typeof errorPayload.error === 'string') {
+        message = errorPayload.error;
+      }
+    } catch {
+      // ignore JSON parse errors
+    }
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const diagramType = normalizeDiagramType(data?.diagramType, payload.diagramType);
+  const mermaidCode = typeof data?.mermaid === 'string' ? data.mermaid : '';
+  const summary = typeof data?.summary === 'string' ? data.summary : undefined;
+
+  if (!mermaidCode) {
+    throw new Error('AI生成されたMermaidコードが空でした。');
+  }
+
+  return {
+    diagramType,
+    mermaidCode,
+    summary,
+  };
+}

--- a/src/lib/mermaid/normalize.ts
+++ b/src/lib/mermaid/normalize.ts
@@ -1,0 +1,28 @@
+export const normalizeMermaidSource = (value: string): string => {
+  if (!value) return '';
+
+  const unified = value
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\u2028\u2029]/g, '\n')
+    .trim();
+
+  if (!unified) return '';
+
+  const lines = unified.split('\n');
+  const headerPattern = /^\s*(flowchart|graph)\s+([A-Za-z]{2})(.*)$/i;
+  const headerMatch = lines[0].match(headerPattern);
+
+  if (headerMatch) {
+    const [, keyword, orientation, rest] = headerMatch;
+    lines[0] = `${keyword} ${orientation.toUpperCase()}`;
+    if (rest && rest.trim().length > 0) {
+      lines.splice(1, 0, rest.trim());
+    }
+  } else {
+    lines[0] = lines[0].trim();
+  }
+
+  return lines
+    .map((line, index) => (index === 0 ? line : line.replace(/\s+$/g, '')))
+    .join('\n');
+};

--- a/src/lib/utils/id.ts
+++ b/src/lib/utils/id.ts
@@ -1,0 +1,12 @@
+export const createId = (prefix = 'id'): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // フォールバックへ
+    }
+  }
+
+  const random = Math.random().toString(16).slice(2);
+  return `${prefix}_${Date.now()}_${random}`;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { MermaidDiagramType } from '@/lib/mermaid/types';
+
 // タブに関する型定義
 export interface TabData {
   id: string;
@@ -43,6 +45,16 @@ export interface PairWritingHistoryEntry {
   targetLanguage?: string | null;
   rewriteInstruction?: string | null;
   createdAt: string;
+}
+
+export interface MermaidGenerationHistoryEntry {
+  id: string;
+  diagramType: MermaidDiagramType;
+  prompt: string;
+  mermaidCode: string;
+  summary?: string;
+  createdAt: string;
+  appliedAt?: string | null;
 }
 
 // ファイルツリーに関する型定義


### PR DESCRIPTION
## Summary
- add a `/api/llm/mermaid` endpoint and shared helper to request Mermaid diagrams from ChatGPT
- enhance Mermaid preview and template dialog with AI generation panels, previews, and adoption/discard flows
- persist Mermaid generation history in the editor store and expose it through updated components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf9877da0832f84ff0ce53c613f06