### PR TITLE
Add AI git assist workflow for commit summaries and reviews

### DIFF
--- a/src/app/api/llm/git-assist/route.ts
+++ b/src/app/api/llm/git-assist/route.ts
@@ -1,0 +1,374 @@
+import { NextResponse } from 'next/server';
+import type { ChatCompletionMessage } from '@/lib/llm/workflowPrompt';
+import type {
+  GitAssistApiResponse,
+  GitAssistDiffPayload,
+  GitAssistFileDiff,
+  GitAssistIntent,
+  GitAssistModelResponse,
+  GitAssistRequestPayload,
+  GitAssistSkippedFile,
+  GitAssistDiffScope,
+  GitFileStatus,
+} from '@/types/git';
+
+class GitAssistApiError extends Error {
+  status: number;
+
+  constructor(message: string, status = 500) {
+    super(message);
+    this.name = 'GitAssistApiError';
+    this.status = status;
+  }
+}
+
+const OPENAI_CHAT_COMPLETION_URL = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = 'gpt-4o-mini';
+const MAX_DIFF_SNIPPET_LENGTH = 12000;
+const MAX_FILE_ENTRIES = 20;
+const VALID_INTENTS: GitAssistIntent[] = ['commit-summary', 'review-comments'];
+const VALID_STATUSES: GitFileStatus[] = ['unmodified', 'modified', 'deleted', 'added', 'untracked', 'absent'];
+const VALID_SCOPES: GitAssistDiffScope[] = ['staged', 'worktree', 'all'];
+
+const gitAssistResponseSchema = {
+  name: 'git_assist_response',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['intent'],
+    properties: {
+      intent: {
+        type: 'string',
+        enum: VALID_INTENTS,
+        description: '応答の種類。commit-summary または review-comments。',
+      },
+      commitMessage: {
+        type: 'string',
+        description: '提案されたコミットメッセージ。',
+      },
+      summary: {
+        type: 'array',
+        maxItems: 8,
+        items: {
+          type: 'string',
+          description: '変更概要の箇条書き。',
+        },
+      },
+      reviewComments: {
+        type: 'array',
+        maxItems: 12,
+        items: {
+          type: 'string',
+          description: 'レビューコメント。',
+        },
+      },
+      warnings: {
+        type: 'array',
+        maxItems: 6,
+        items: {
+          type: 'string',
+          description: '注意点や警告。',
+        },
+      },
+    },
+  },
+} as const;
+
+function normalizeIntent(value: unknown): GitAssistIntent | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim() as GitAssistIntent;
+  return VALID_INTENTS.includes(trimmed) ? trimmed : null;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeScope(value: unknown): GitAssistDiffScope {
+  if (typeof value === 'string') {
+    const trimmed = value.trim() as GitAssistDiffScope;
+    if (VALID_SCOPES.includes(trimmed)) {
+      return trimmed;
+    }
+  }
+  return 'staged';
+}
+
+function normalizeStatus(value: unknown): GitFileStatus {
+  if (typeof value === 'string') {
+    const trimmed = value.trim() as GitFileStatus;
+    if (VALID_STATUSES.includes(trimmed)) {
+      return trimmed;
+    }
+  }
+  return 'modified';
+}
+
+function sanitizeSkipped(value: unknown): GitAssistSkippedFile[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const entries: GitAssistSkippedFile[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+    const path = typeof (item as any).path === 'string' ? (item as any).path : null;
+    if (!path) {
+      continue;
+    }
+    const reason = (item as any).reason === 'sensitive' ? 'sensitive' : 'error';
+    const message = typeof (item as any).message === 'string' ? (item as any).message : undefined;
+    entries.push({ path, reason, message });
+  }
+  return entries;
+}
+
+function sanitizeFiles(value: unknown): GitAssistFileDiff[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const files: GitAssistFileDiff[] = [];
+  for (const item of value.slice(0, MAX_FILE_ENTRIES)) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+    const path = typeof (item as any).path === 'string' ? (item as any).path : null;
+    if (!path) {
+      continue;
+    }
+    const diff = typeof (item as any).diff === 'string' ? (item as any).diff : null;
+    files.push({
+      path,
+      worktreeStatus: normalizeStatus((item as any).worktreeStatus),
+      stagedStatus: normalizeStatus((item as any).stagedStatus),
+      isStaged: Boolean((item as any).isStaged),
+      isUntracked: Boolean((item as any).isUntracked),
+      diff,
+      isBinary: Boolean((item as any).isBinary),
+      headSize: typeof (item as any).headSize === 'number' ? (item as any).headSize : null,
+      worktreeSize: typeof (item as any).worktreeSize === 'number' ? (item as any).worktreeSize : null,
+    });
+  }
+  return files;
+}
+
+function sanitizeDiffPayload(value: unknown, fallbackBranch: string | null): GitAssistDiffPayload | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const branch = typeof (value as any).branch === 'string' ? (value as any).branch : fallbackBranch;
+  const scope = normalizeScope((value as any).scope);
+  const files = sanitizeFiles((value as any).files);
+  const skipped = sanitizeSkipped((value as any).skipped);
+  return {
+    branch: branch ?? null,
+    scope,
+    files,
+    skipped,
+  };
+}
+
+function truncateDiff(diff: string | null): string | null {
+  if (typeof diff !== 'string') {
+    return null;
+  }
+  if (diff.length <= MAX_DIFF_SNIPPET_LENGTH) {
+    return diff;
+  }
+  return `${diff.slice(0, MAX_DIFF_SNIPPET_LENGTH)}\n... (diff truncated)`;
+}
+
+function formatFileEntry(file: GitAssistFileDiff, index: number): string {
+  const lines: string[] = [];
+  lines.push(`### File ${index + 1}: ${file.path}`);
+  lines.push(`- 状態: worktree=${file.worktreeStatus}, staged=${file.stagedStatus}, isStaged=${file.isStaged}, isUntracked=${file.isUntracked}`);
+  lines.push(`- サイズ: HEAD=${file.headSize ?? 0} bytes, 作業ツリー=${file.worktreeSize ?? 0} bytes`);
+  if (file.isBinary) {
+    lines.push('- このファイルはバイナリのため差分を省略しました。');
+  } else if (file.diff) {
+    lines.push('```diff');
+    lines.push(truncateDiff(file.diff) ?? '');
+    lines.push('```');
+  } else {
+    lines.push('- 差分を取得できませんでした。');
+  }
+  return lines.join('\n');
+}
+
+function buildUserContent(payload: GitAssistRequestPayload): string {
+  const segments: string[] = [];
+  segments.push(`Intent: ${payload.intent}`);
+  if (payload.branch) {
+    segments.push(`Current branch: ${payload.branch}`);
+  }
+  segments.push(`Diff scope: ${payload.diff.scope}`);
+  if (payload.commitPurpose) {
+    segments.push(`Commit purpose: ${payload.commitPurpose}`);
+  }
+  if (payload.diff.skipped.length > 0) {
+    segments.push('Skipped files (not shared with the model):');
+    for (const skipped of payload.diff.skipped) {
+      segments.push(`- ${skipped.path} (${skipped.reason})${skipped.message ? `: ${skipped.message}` : ''}`);
+    }
+  }
+
+  if (payload.diff.files.length === 0) {
+    segments.push('No diff content was provided.');
+  } else {
+    segments.push('Changed files:');
+    payload.diff.files.forEach((file, index) => {
+      segments.push(formatFileEntry(file, index));
+    });
+  }
+
+  segments.push('Respond in Japanese.');
+  return segments.join('\n\n');
+}
+
+function buildMessages(payload: GitAssistRequestPayload): ChatCompletionMessage[] {
+  const intentInstruction =
+    payload.intent === 'commit-summary'
+      ? 'Provide a concise commit message and bullet summary of the changes.'
+      : 'Provide specific code review comments pointing out potential issues or improvements.';
+
+  const systemPrompt = [
+    'You are an experienced software engineer assisting with Git workflows.',
+    'When asked for a commit summary, craft a clear Japanese commit message (max 72 chars) and 1-4 bullet summary items.',
+    'When asked for review comments, produce actionable Japanese comments referencing the provided diff.',
+    'Do not invent details that are not supported by the diff.',
+    'Always return JSON that satisfies the provided schema. Do not include extra commentary.',
+  ].join(' ');
+
+  const userContent = [intentInstruction, buildUserContent(payload)].join('\n\n');
+
+  return [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userContent },
+  ];
+}
+
+function normalizeModelResponse(data: unknown, fallbackIntent: GitAssistIntent): GitAssistModelResponse {
+  const intent = normalizeIntent((data as any)?.intent) ?? fallbackIntent;
+  const commitMessage = normalizeOptionalString((data as any)?.commitMessage) ?? null;
+  const rawSummary = Array.isArray((data as any)?.summary) ? (data as any).summary : [];
+  const summary = rawSummary
+    .map((item: unknown) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item: string) => item.length > 0);
+  const rawReview = Array.isArray((data as any)?.reviewComments) ? (data as any).reviewComments : [];
+  const reviewComments = rawReview
+    .map((item: unknown) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item: string) => item.length > 0);
+  const rawWarnings = Array.isArray((data as any)?.warnings) ? (data as any).warnings : [];
+  const warnings = rawWarnings
+    .map((item: unknown) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item: string) => item.length > 0);
+
+  const response: GitAssistModelResponse = {
+    intent,
+  };
+
+  if (commitMessage) {
+    response.commitMessage = commitMessage;
+  }
+  if (summary.length > 0) {
+    response.summary = summary;
+  }
+  if (reviewComments.length > 0) {
+    response.reviewComments = reviewComments;
+  }
+  if (warnings.length > 0) {
+    response.warnings = warnings;
+  }
+
+  return response;
+}
+
+async function callGitAssistModel(apiKey: string, payload: GitAssistRequestPayload): Promise<GitAssistApiResponse> {
+  const messages = buildMessages(payload);
+  const temperature = payload.intent === 'commit-summary' ? 0.2 : 0.3;
+
+  const response = await fetch(OPENAI_CHAT_COMPLETION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: DEFAULT_MODEL,
+      temperature,
+      response_format: {
+        type: 'json_schema',
+        json_schema: gitAssistResponseSchema,
+      },
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = 'ChatGPT APIの呼び出しに失敗しました。';
+    try {
+      const errorPayload = await response.json();
+      message = errorPayload?.error?.message || message;
+    } catch {
+      // ignore JSON parse errors
+    }
+    const status = response.status >= 400 && response.status < 500 ? response.status : 502;
+    throw new GitAssistApiError(message, status);
+  }
+
+  const data = await response.json();
+  const content: unknown = data?.choices?.[0]?.message?.content;
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new Error('モデルから有効な応答を取得できませんでした。');
+  }
+
+  const parsed = JSON.parse(content);
+  return normalizeModelResponse(parsed, payload.intent);
+}
+
+export async function POST(request: Request) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'OPENAI_API_KEY が設定されていません。' }, { status: 500 });
+    }
+
+    const body: Partial<GitAssistRequestPayload> = await request.json();
+    const intent = normalizeIntent(body?.intent);
+    if (!intent) {
+      return NextResponse.json({ error: 'intent には commit-summary または review-comments を指定してください。' }, { status: 400 });
+    }
+
+    const branch = normalizeOptionalString(body?.branch) ?? null;
+    const commitPurpose = normalizeOptionalString(body?.commitPurpose);
+    const diff = sanitizeDiffPayload(body?.diff, branch);
+
+    if (!diff || diff.files.length === 0) {
+      return NextResponse.json({ error: '送信可能な差分がありません。' }, { status: 400 });
+    }
+
+    const payload: GitAssistRequestPayload = {
+      intent,
+      branch: diff.branch ?? branch,
+      commitPurpose,
+      diff,
+    };
+
+    const result = await callGitAssistModel(apiKey, payload);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Git assist API error:', error);
+    const message = error instanceof Error ? error.message : 'AIアシスト処理中にエラーが発生しました。';
+    const status = error instanceof GitAssistApiError ? error.status : 502;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/components/git/GitAssistReviewResult.tsx
+++ b/src/components/git/GitAssistReviewResult.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { IoClipboardOutline, IoCloseOutline, IoWarningOutline } from 'react-icons/io5';
+
+interface GitAssistReviewResultProps {
+  value: string;
+  onChange: (value: string) => void;
+  warnings: string[];
+  disabled?: boolean;
+  loading?: boolean;
+  onClear?: () => void;
+}
+
+const GitAssistReviewResult: React.FC<GitAssistReviewResultProps> = ({
+  value,
+  onChange,
+  warnings,
+  disabled,
+  loading,
+  onClear,
+}) => {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const canCopy = useMemo(() => value.trim().length > 0, [value]);
+
+  const handleCopy = async () => {
+    if (!canCopy || disabled) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState('copied');
+      setTimeout(() => setCopyState('idle'), 2000);
+    } catch (error) {
+      console.error('Failed to copy review comments:', error);
+      setCopyState('failed');
+      setTimeout(() => setCopyState('idle'), 2500);
+    }
+  };
+
+  const hasContent = canCopy || warnings.length > 0;
+
+  return (
+    <div className="rounded border border-slate-200 bg-slate-50 p-3 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-semibold text-slate-900 dark:text-slate-100">AI レビューコメント</p>
+          <p className="text-xs text-slate-700 dark:text-slate-300/80">気になる点を箇条書きで提示します。必要に応じて編集してご利用ください。</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {onClear && (
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+              onClick={onClear}
+              disabled={disabled || (!hasContent && !loading)}
+            >
+              <IoCloseOutline size={14} />
+              クリア
+            </button>
+          )}
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded border border-slate-400 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-500 dark:text-slate-200 dark:hover:bg-slate-800"
+            onClick={handleCopy}
+            disabled={disabled || !canCopy}
+          >
+            <IoClipboardOutline size={14} />
+            コピー
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-700 dark:text-slate-200">提案されたレビューコメント</label>
+          <textarea
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            className="h-28 w-full resize-y rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 shadow-inner focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-400"
+            placeholder={loading ? '生成中...' : 'AIによるレビューコメントがここに表示されます。'}
+            disabled={disabled || loading}
+          />
+        </div>
+
+        {loading && <p className="text-xs text-slate-600 dark:text-slate-300">コメントを生成しています...</p>}
+
+        {warnings.length > 0 && (
+          <div className="flex items-start gap-2 rounded border border-amber-300 bg-amber-100/80 px-2 py-2 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/30 dark:text-amber-100">
+            <IoWarningOutline size={16} className="mt-[2px]" />
+            <div>
+              <p className="font-semibold">注意事項</p>
+              <ul className="mt-1 list-disc space-y-1 pl-4">
+                {warnings.map((warning, index) => (
+                  <li key={`${warning}-${index}`}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {copyState === 'copied' && (
+          <p className="text-xs font-medium text-emerald-700 dark:text-emerald-300">クリップボードにコピーしました。</p>
+        )}
+        {copyState === 'failed' && (
+          <p className="text-xs font-medium text-rose-600 dark:text-rose-300">コピーに失敗しました。手動で選択してコピーしてください。</p>
+        )}
+
+        {!loading && !hasContent && (
+          <p className="text-xs text-slate-600 dark:text-slate-300">AIにレビューコメントを依頼すると結果がここに表示されます。</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GitAssistReviewResult;

--- a/src/components/git/GitAssistSummaryResult.tsx
+++ b/src/components/git/GitAssistSummaryResult.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React from 'react';
+import { IoCheckmarkCircleOutline, IoCloseOutline } from 'react-icons/io5';
+
+interface GitAssistSummaryResultProps {
+  value: string;
+  onChange: (value: string) => void;
+  summary: string[];
+  warnings: string[];
+  onApply?: () => void;
+  onClear?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+const GitAssistSummaryResult: React.FC<GitAssistSummaryResultProps> = ({
+  value,
+  onChange,
+  summary,
+  warnings,
+  onApply,
+  onClear,
+  disabled,
+  loading,
+}) => {
+  const hasContent = value.trim().length > 0 || summary.length > 0 || warnings.length > 0;
+
+  return (
+    <div className="rounded border border-blue-200 bg-blue-50/60 p-3 text-sm shadow-sm dark:border-blue-900/50 dark:bg-blue-950/30">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-semibold text-blue-900 dark:text-blue-100">AI コミット要約</p>
+          <p className="text-xs text-blue-900/70 dark:text-blue-200/80">提案を確認・編集してからコミットメッセージに反映できます。</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {onClear && (
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded border border-blue-200 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800 dark:text-blue-200 dark:hover:bg-blue-900/40"
+              onClick={onClear}
+              disabled={disabled || (!hasContent && !loading)}
+            >
+              <IoCloseOutline size={14} />
+              クリア
+            </button>
+          )}
+          {onApply && (
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={onApply}
+              disabled={disabled || value.trim().length === 0}
+            >
+              <IoCheckmarkCircleOutline size={14} />
+              反映
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-blue-900/80 dark:text-blue-100">提案されたコミットメッセージ</label>
+          <textarea
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            className="h-20 w-full resize-y rounded border border-blue-200 bg-white px-2 py-1 text-sm text-blue-900 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100 dark:focus:border-blue-400"
+            placeholder={loading ? '生成中...' : 'AIによるコミットメッセージの提案がここに表示されます。'}
+            disabled={disabled || loading}
+          />
+        </div>
+
+        {loading && (
+          <p className="text-xs text-blue-700 dark:text-blue-200">生成中です。少しお待ちください...</p>
+        )}
+
+        {summary.length > 0 && (
+          <div>
+            <p className="mb-1 text-xs font-medium text-blue-900/80 dark:text-blue-100">変更概要</p>
+            <ul className="list-disc space-y-1 pl-5 text-xs text-blue-900 dark:text-blue-100">
+              {summary.map((item, index) => (
+                <li key={`${item}-${index}`}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {warnings.length > 0 && (
+          <div className="rounded border border-yellow-300 bg-yellow-100/90 px-2 py-1 text-xs text-yellow-900 dark:border-yellow-900/60 dark:bg-yellow-950/40 dark:text-yellow-100">
+            <p className="font-semibold">注意事項</p>
+            <ul className="mt-1 list-disc space-y-1 pl-4">
+              {warnings.map((warning, index) => (
+                <li key={`${warning}-${index}`}>{warning}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {!loading && !hasContent && (
+          <p className="text-xs text-blue-800/80 dark:text-blue-200/80">AIにコミット要約を依頼すると結果がここに表示されます。</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GitAssistSummaryResult;

--- a/src/lib/llm/gitAssist.ts
+++ b/src/lib/llm/gitAssist.ts
@@ -1,0 +1,80 @@
+import type { GitAssistApiResponse, GitAssistIntent, GitAssistRequestPayload } from '@/types/git';
+
+const VALID_INTENTS: GitAssistIntent[] = ['commit-summary', 'review-comments'];
+
+function normalizeIntent(value: unknown, fallback: GitAssistIntent): GitAssistIntent {
+  if (typeof value === 'string') {
+    const trimmed = value.trim() as GitAssistIntent;
+    if (VALID_INTENTS.includes(trimmed)) {
+      return trimmed;
+    }
+  }
+  return fallback;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized = value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item): item is string => item.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export async function requestGitAssist(payload: GitAssistRequestPayload): Promise<GitAssistApiResponse> {
+  const response = await fetch('/api/llm/git-assist', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `Gitアシストの呼び出しに失敗しました。（${response.status}）`;
+    try {
+      const errorPayload = await response.json();
+      if (errorPayload && typeof errorPayload.error === 'string') {
+        message = errorPayload.error;
+      }
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const intent = normalizeIntent(data?.intent, payload.intent);
+  const commitMessage = normalizeOptionalString(data?.commitMessage);
+  const summary = normalizeStringArray(data?.summary);
+  const reviewComments = normalizeStringArray(data?.reviewComments);
+  const warnings = normalizeStringArray(data?.warnings);
+
+  const result: GitAssistApiResponse = {
+    intent,
+  };
+
+  if (commitMessage) {
+    result.commitMessage = commitMessage;
+  }
+  if (summary) {
+    result.summary = summary;
+  }
+  if (reviewComments) {
+    result.reviewComments = reviewComments;
+  }
+  if (warnings) {
+    result.warnings = warnings;
+  }
+
+  return result;
+}

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -1,0 +1,49 @@
+export type GitFileStatus = 'unmodified' | 'modified' | 'deleted' | 'added' | 'untracked' | 'absent';
+
+export type GitAssistIntent = 'commit-summary' | 'review-comments';
+
+export type GitAssistDiffScope = 'staged' | 'worktree' | 'all';
+
+export interface GitAssistFileDiff {
+  path: string;
+  worktreeStatus: GitFileStatus;
+  stagedStatus: GitFileStatus;
+  isStaged: boolean;
+  isUntracked: boolean;
+  diff: string | null;
+  isBinary: boolean;
+  headSize: number | null;
+  worktreeSize: number | null;
+}
+
+export type GitAssistSkipReason = 'sensitive' | 'error';
+
+export interface GitAssistSkippedFile {
+  path: string;
+  reason: GitAssistSkipReason;
+  message?: string;
+}
+
+export interface GitAssistDiffPayload {
+  branch: string | null;
+  scope: GitAssistDiffScope;
+  files: GitAssistFileDiff[];
+  skipped: GitAssistSkippedFile[];
+}
+
+export interface GitAssistRequestPayload {
+  intent: GitAssistIntent;
+  branch?: string | null;
+  commitPurpose?: string | null;
+  diff: GitAssistDiffPayload;
+}
+
+export interface GitAssistModelResponse {
+  intent: GitAssistIntent;
+  commitMessage?: string | null;
+  summary?: string[] | null;
+  reviewComments?: string[] | null;
+  warnings?: string[] | null;
+}
+
+export type GitAssistApiResponse = GitAssistModelResponse;


### PR DESCRIPTION
## Summary
- add a reusable diff payload helper with sensitive file filtering in the git store
- introduce a `/api/llm/git-assist` endpoint and client helper for ChatGPT-powered commit summaries and review comments
- extend the Git panel with AI assist actions, result editors, and supporting UI components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc6d69716c832fb4a1aac1b617844a