### PR TITLE
Add AI help sidebar with sanitized MyGPT support

### DIFF
--- a/src/app/api/llm/help/route.ts
+++ b/src/app/api/llm/help/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from 'next/server';
+import type { HelpMessageRole } from '@/types';
+
+const OPENAI_CHAT_COMPLETION_URL = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_HELP_MODEL = process.env.OPENAI_HELP_MODEL || 'gpt-4o-mini';
+const HELP_TEMPERATURE = 0.2;
+
+type ChatCompletionMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+type NormalizedHistoryItem = { role: HelpMessageRole; content: string };
+
+interface HelpRequestBody {
+  query?: unknown;
+  documentId?: unknown;
+  knowledgeBaseUrl?: unknown;
+  context?: unknown;
+  history?: unknown;
+  maskedFiles?: unknown;
+}
+
+function normalizeString(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function normalizeHistory(value: unknown): NormalizedHistoryItem[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') {
+        return null;
+      }
+      const role = (item as { role?: unknown }).role;
+      const content = (item as { content?: unknown }).content;
+      if ((role === 'user' || role === 'assistant') && typeof content === 'string' && content.trim().length > 0) {
+        return { role, content: content.trim() } as NormalizedHistoryItem;
+      }
+      return null;
+    })
+    .filter((item): item is NormalizedHistoryItem => Boolean(item));
+}
+
+function buildMessages(params: {
+  query: string;
+  documentId: string;
+  knowledgeBaseUrl: string;
+  context?: string | null;
+  history: NormalizedHistoryItem[];
+  maskedFiles?: { path?: unknown; reason?: unknown }[];
+}): ChatCompletionMessage[] {
+  const { query, documentId, knowledgeBaseUrl, context, history, maskedFiles } = params;
+
+  const maskedSummary = Array.isArray(maskedFiles)
+    ? maskedFiles
+        .map((item) => {
+          const path = typeof item?.path === 'string' ? item.path : 'unknown';
+          const reason = typeof item?.reason === 'string' ? item.reason : 'マスク済み';
+          return `- ${path}: ${reason}`;
+        })
+        .join('\n')
+    : '';
+
+  const userSegments = [
+    '次の質問にMyGPTナレッジベースを参照して回答してください。',
+    `質問: ${query}`,
+    `ドキュメントID: ${documentId}`,
+    `ナレッジベースURL: ${knowledgeBaseUrl}`,
+  ];
+
+  if (context && context.trim().length > 0) {
+    userSegments.push('---');
+    userSegments.push('追加コンテキスト:');
+    userSegments.push(context.trim());
+  }
+
+  if (maskedSummary) {
+    userSegments.push('---');
+    userSegments.push('マスクされたファイル:');
+    userSegments.push(maskedSummary);
+  }
+
+  const messages: ChatCompletionMessage[] = [
+    {
+      role: 'system',
+      content: [
+        'あなたはDataLoom StudioのAIサポートアシスタントです。',
+        '提供されたMyGPTナレッジベースの情報と補足コンテキストを活用して、実務的で簡潔な回答を日本語で作成してください。',
+        '根拠となるドキュメントIDやURLが分かる場合は回答中に言及してください。',
+        '不明な点があれば推測せず、その旨を伝えてください。',
+      ].join('\n'),
+    },
+    ...history.map((item) => ({ role: item.role, content: item.content })),
+    { role: 'user', content: userSegments.join('\n') },
+  ];
+
+  return messages;
+}
+
+export async function POST(request: Request) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'OPENAI_API_KEY が設定されていません。' }, { status: 500 });
+    }
+
+    const body: HelpRequestBody = await request.json();
+    const query = normalizeString(body.query);
+    const documentId = normalizeString(body.documentId);
+    const knowledgeBaseUrl = normalizeString(body.knowledgeBaseUrl);
+    const context = typeof body.context === 'string' ? body.context : null;
+    const history = normalizeHistory(body.history);
+    const maskedFiles = Array.isArray(body.maskedFiles) ? body.maskedFiles : undefined;
+
+    if (!query) {
+      return NextResponse.json({ error: '問い合わせ内容を入力してください。' }, { status: 400 });
+    }
+    if (!documentId) {
+      return NextResponse.json({ error: 'ドキュメントIDを指定してください。' }, { status: 400 });
+    }
+    if (!knowledgeBaseUrl) {
+      return NextResponse.json({ error: 'ナレッジベースのURLを指定してください。' }, { status: 400 });
+    }
+
+    const messages = buildMessages({
+      query,
+      documentId,
+      knowledgeBaseUrl,
+      context,
+      history,
+      maskedFiles,
+    });
+
+    const response = await fetch(OPENAI_CHAT_COMPLETION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: DEFAULT_HELP_MODEL,
+        temperature: HELP_TEMPERATURE,
+        messages,
+      }),
+    });
+
+    if (!response.ok) {
+      let message = 'ヘルプ応答の生成に失敗しました。';
+      try {
+        const errorPayload = await response.json();
+        message = errorPayload?.error?.message || message;
+      } catch {
+        // ignore parse error
+      }
+      return NextResponse.json({ error: message }, { status: response.status });
+    }
+
+    const data = await response.json();
+    const answer: string | undefined = data?.choices?.[0]?.message?.content;
+    const usage = data?.usage
+      ? {
+          promptTokens: typeof data.usage.prompt_tokens === 'number' ? data.usage.prompt_tokens : undefined,
+          completionTokens: typeof data.usage.completion_tokens === 'number' ? data.usage.completion_tokens : undefined,
+          totalTokens: typeof data.usage.total_tokens === 'number' ? data.usage.total_tokens : undefined,
+        }
+      : null;
+
+    if (!answer) {
+      return NextResponse.json({ error: 'モデルから有効な応答を取得できませんでした。' }, { status: 502 });
+    }
+
+    return NextResponse.json({
+      answer: answer.trim(),
+      documentId,
+      knowledgeBaseUrl,
+      usage,
+    });
+  } catch (error) {
+    console.error('Help API error:', error);
+    const message = error instanceof Error ? error.message : 'ヘルプ処理中にエラーが発生しました。';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/help/HelpSidebar.tsx
+++ b/src/components/help/HelpSidebar.tsx
@@ -1,0 +1,454 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IoAddOutline, IoTrashOutline } from 'react-icons/io5';
+import { useEditorStore } from '@/store/editorStore';
+import { sanitizeHelpRequest } from '@/lib/llm/helpSanitizer';
+import { requestHelp } from '@/lib/llm/helpClient';
+import { createId } from '@/lib/utils/id';
+import type { HelpMessage, HelpThread, HelpUserRole } from '@/types';
+
+const ROLE_LABELS: Record<HelpUserRole, string> = {
+  viewer: '閲覧者',
+  editor: '編集者',
+  admin: '管理者',
+};
+
+const threadTitle = (thread: HelpThread | undefined) => thread?.title || '無題のスレッド';
+
+const HelpSidebar: React.FC = () => {
+  const {
+    helpThreads,
+    helpThreadOrder,
+    activeHelpThreadId,
+    setActiveHelpThread,
+    createHelpThread,
+    addHelpMessage,
+    removeHelpThread,
+    updateHelpThread,
+    helpSettings,
+    updateHelpSettings,
+  } = useEditorStore((state) => ({
+    helpThreads: state.helpThreads,
+    helpThreadOrder: state.helpThreadOrder,
+    activeHelpThreadId: state.activeHelpThreadId,
+    setActiveHelpThread: state.setActiveHelpThread,
+    createHelpThread: state.createHelpThread,
+    addHelpMessage: state.addHelpMessage,
+    removeHelpThread: state.removeHelpThread,
+    updateHelpThread: state.updateHelpThread,
+    helpSettings: state.helpSettings,
+    updateHelpSettings: state.updateHelpSettings,
+  }));
+
+  const { activeTabId, tabs } = useEditorStore((state) => ({ activeTabId: state.activeTabId, tabs: state.tabs }));
+  const activeTab = useMemo(() => (activeTabId ? tabs.get(activeTabId) : undefined), [activeTabId, tabs]);
+
+  const activeThread = activeHelpThreadId ? helpThreads[activeHelpThreadId] : undefined;
+
+  const [message, setMessage] = useState('');
+  const [includeActiveTab, setIncludeActiveTab] = useState(true);
+  const [status, setStatus] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [lastMaskedSummary, setLastMaskedSummary] = useState<{ files: string[]; patterns: string[] } | null>(null);
+
+  useEffect(() => {
+    if (!activeHelpThreadId) {
+      if (helpThreadOrder.length > 0) {
+        setActiveHelpThread(helpThreadOrder[0]);
+      } else {
+        const thread = createHelpThread();
+        setActiveHelpThread(thread.id);
+      }
+    }
+  }, [activeHelpThreadId, helpThreadOrder, setActiveHelpThread, createHelpThread]);
+
+  const handleSelectThread = useCallback(
+    (threadId: string) => {
+      setActiveHelpThread(threadId);
+      setStatus(null);
+      setLastMaskedSummary(null);
+    },
+    [setActiveHelpThread],
+  );
+
+  const handleNewThread = useCallback(() => {
+    const thread = createHelpThread({ title: '新しい問い合わせ' });
+    setActiveHelpThread(thread.id);
+    setStatus(null);
+    setMessage('');
+  }, [createHelpThread, setActiveHelpThread]);
+
+  const handleRemoveThread = useCallback(
+    (threadId: string) => {
+      if (helpThreadOrder.length <= 1) {
+        // 最後のスレッドは削除せず初期化
+        updateHelpThread(threadId, { messages: [], title: '新しい問い合わせ', updatedAt: new Date().toISOString() });
+        setStatus(null);
+        return;
+      }
+      removeHelpThread(threadId);
+    },
+    [helpThreadOrder.length, removeHelpThread, updateHelpThread],
+  );
+
+  const handleUpdateDocumentInfo = useCallback(
+    (field: 'documentId' | 'knowledgeBaseUrl', value: string) => {
+      if (!activeThread) return;
+      if (field === 'documentId') {
+        updateHelpThread(activeThread.id, { documentId: value });
+      } else {
+        updateHelpThread(activeThread.id, { knowledgeBaseUrl: value });
+      }
+    },
+    [activeThread, updateHelpThread],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!activeThread) {
+        setStatus('スレッドの準備が完了していません。');
+        return;
+      }
+
+      const trimmed = message.trim();
+      if (!trimmed) {
+        setStatus('問い合わせ内容を入力してください。');
+        return;
+      }
+
+      const documentId = (activeThread.documentId || helpSettings.defaultDocumentId || '').trim();
+      const knowledgeBaseUrl = (activeThread.knowledgeBaseUrl || helpSettings.defaultKnowledgeBaseUrl || '').trim();
+
+      if (!documentId || !knowledgeBaseUrl) {
+        setStatus('ドキュメントIDとナレッジベースURLを設定してください。');
+        return;
+      }
+
+      const attachments = includeActiveTab && activeTab
+        ? [{ path: activeTab.name, content: typeof activeTab.content === 'string' ? activeTab.content : JSON.stringify(activeTab.content) }]
+        : [];
+
+      const sanitized = sanitizeHelpRequest(
+        { query: trimmed, files: attachments },
+        {
+          maskFileContent: helpSettings.maskFileContent,
+          userRole: helpSettings.currentRole,
+          allowedRoles: helpSettings.allowedRoles,
+        },
+      );
+
+      if (sanitized.blocked) {
+        setStatus(sanitized.blockReason || '現在の権限では送信できません。');
+        setLastMaskedSummary({ files: [], patterns: sanitized.maskedPatterns });
+        return;
+      }
+
+      const maskedFileLabels = sanitized.maskedFiles.map((item) => `${item.path} (${item.reason})`);
+      setLastMaskedSummary({ files: maskedFileLabels, patterns: sanitized.maskedPatterns });
+      setStatus(null);
+      setIsSending(true);
+
+      const now = new Date().toISOString();
+      const userMessage: HelpMessage = {
+        id: createId('help_user'),
+        role: 'user',
+        content: sanitized.sanitizedQuery,
+        createdAt: now,
+        metadata: {
+          maskedFiles: sanitized.maskedFiles,
+          maskedPatterns: sanitized.maskedPatterns,
+        },
+      };
+
+      const historyPayload = (activeThread.messages || []).map((item) => ({ role: item.role, content: item.content }));
+      historyPayload.push({ role: 'user', content: sanitized.sanitizedQuery });
+
+      addHelpMessage(activeThread.id, userMessage);
+      setMessage('');
+
+      try {
+        const response = await requestHelp({
+          query: sanitized.sanitizedQuery,
+          documentId,
+          knowledgeBaseUrl,
+          context: sanitized.context,
+          history: historyPayload,
+          maskedFiles: sanitized.maskedFiles,
+        });
+
+        const assistantMessage: HelpMessage = {
+          id: createId('help_ai'),
+          role: 'assistant',
+          content: response.answer,
+          createdAt: new Date().toISOString(),
+        };
+        addHelpMessage(activeThread.id, assistantMessage);
+        setStatus(null);
+      } catch (error) {
+        console.error('Failed to request help:', error);
+        setStatus(error instanceof Error ? error.message : 'ヘルプの取得に失敗しました。');
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [
+      activeThread,
+      message,
+      includeActiveTab,
+      activeTab,
+      helpSettings.maskFileContent,
+      helpSettings.currentRole,
+      helpSettings.allowedRoles,
+      helpSettings.defaultDocumentId,
+      helpSettings.defaultKnowledgeBaseUrl,
+      addHelpMessage,
+    ],
+  );
+
+  const handleRoleChange = useCallback(
+    (role: HelpUserRole) => {
+      updateHelpSettings({ currentRole: role });
+    },
+    [updateHelpSettings],
+  );
+
+  const handleToggleRolePermission = useCallback(
+    (role: HelpUserRole) => {
+      const current = helpSettings.allowedRoles[role];
+      updateHelpSettings({
+        allowedRoles: {
+          ...helpSettings.allowedRoles,
+          [role]: !current,
+        },
+      });
+    },
+    [helpSettings.allowedRoles, updateHelpSettings],
+  );
+
+  const handleDefaultDocChange = useCallback(
+    (field: 'defaultDocumentId' | 'defaultKnowledgeBaseUrl', value: string) => {
+      updateHelpSettings({ [field]: value });
+    },
+    [updateHelpSettings],
+  );
+
+  return (
+    <div className="flex h-full flex-col bg-gray-50 dark:bg-slate-900">
+      <div className="border-b border-gray-200 p-3 dark:border-slate-800">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200">AIヘルプ</h2>
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-500"
+            onClick={handleNewThread}
+          >
+            <IoAddOutline size={16} /> 新規
+          </button>
+        </div>
+        <div className="mt-3 flex gap-2 overflow-x-auto">
+          {helpThreadOrder.map((threadId) => {
+            const thread = helpThreads[threadId];
+            const isActive = activeHelpThreadId === threadId;
+            return (
+              <div key={threadId} className={`flex items-center rounded border px-2 py-1 text-xs ${isActive ? 'border-blue-500 bg-blue-100 dark:border-blue-400 dark:bg-blue-900/40' : 'border-gray-300 bg-white dark:border-slate-700 dark:bg-slate-800'}`}>
+                <button
+                  type="button"
+                  className={`max-w-[140px] truncate text-left ${isActive ? 'text-blue-700 dark:text-blue-200' : 'text-gray-700 dark:text-gray-200'}`}
+                  onClick={() => handleSelectThread(threadId)}
+                >
+                  {threadTitle(thread)}
+                </button>
+                <button
+                  type="button"
+                  className="ml-1 text-gray-400 hover:text-red-500"
+                  onClick={() => handleRemoveThread(threadId)}
+                  title="スレッドを削除"
+                >
+                  <IoTrashOutline size={14} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="border-b border-gray-200 p-3 text-xs dark:border-slate-800">
+        <label className="mb-2 block font-semibold text-gray-600 dark:text-gray-300">このスレッドのナレッジベース情報</label>
+        <div className="space-y-2">
+          <div>
+            <span className="block text-[11px] text-gray-500">ドキュメントID</span>
+            <input
+              type="text"
+              value={activeThread?.documentId ?? ''}
+              onChange={(event) => handleUpdateDocumentInfo('documentId', event.target.value)}
+              className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+          <div>
+            <span className="block text-[11px] text-gray-500">ナレッジベースURL</span>
+            <input
+              type="text"
+              value={activeThread?.knowledgeBaseUrl ?? ''}
+              onChange={(event) => handleUpdateDocumentInfo('knowledgeBaseUrl', event.target.value)}
+              className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="space-y-3">
+          {activeThread?.messages.map((msg) => {
+            const isUser = msg.role === 'user';
+            return (
+              <div
+                key={msg.id}
+                className={`max-w-full rounded-lg border px-3 py-2 text-xs leading-relaxed ${
+                  isUser
+                    ? 'ml-auto border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-500/40 dark:bg-blue-900/30 dark:text-blue-100'
+                    : 'mr-auto border-gray-200 bg-white text-gray-800 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-100'
+                }`}
+              >
+                <pre className="whitespace-pre-wrap break-words font-sans text-xs">{msg.content}</pre>
+                {msg.metadata?.maskedFiles && msg.metadata.maskedFiles.length > 0 && (
+                  <div className="mt-2 rounded bg-white/40 p-2 text-[10px] text-gray-500 dark:bg-slate-900/40 dark:text-gray-400">
+                    <p className="font-semibold">マスク情報</p>
+                    <ul className="list-disc pl-4">
+                      {msg.metadata.maskedFiles.map((item) => (
+                        <li key={`${item.path}-${item.reason}`}>{item.path}: {item.reason}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {!activeThread?.messages?.length && (
+            <p className="text-center text-xs text-gray-500 dark:text-gray-400">問い合わせ内容を入力して、AIヘルプに質問しましょう。</p>
+          )}
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="border-t border-gray-200 p-3 dark:border-slate-800">
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-200">問い合わせ内容</label>
+        <textarea
+          className="mt-1 w-full rounded border border-gray-300 bg-white p-2 text-xs dark:border-slate-700 dark:bg-slate-800 dark:text-gray-100"
+          rows={4}
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          disabled={isSending}
+        />
+        <div className="mt-2 flex items-center justify-between text-[11px] text-gray-600 dark:text-gray-300">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={includeActiveTab}
+              onChange={(event) => setIncludeActiveTab(event.target.checked)}
+            />
+            アクティブなファイル内容をコンテキストとして送信
+          </label>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+            disabled={isSending}
+          >
+            {isSending ? '送信中...' : '送信'}
+          </button>
+        </div>
+        {status && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{status}</p>}
+        {lastMaskedSummary && (lastMaskedSummary.files.length > 0 || lastMaskedSummary.patterns.length > 0) && (
+          <div className="mt-2 rounded bg-yellow-50 p-2 text-[10px] text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200">
+            <p className="font-semibold">マスクされた情報</p>
+            {lastMaskedSummary.files.length > 0 && (
+              <div className="mt-1">
+                <p>ファイル:</p>
+                <ul className="list-disc pl-4">
+                  {lastMaskedSummary.files.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {lastMaskedSummary.patterns.length > 0 && (
+              <div className="mt-1">
+                <p>検知された機密情報:</p>
+                <ul className="list-disc pl-4">
+                  {lastMaskedSummary.patterns.map((item) => (
+                    <li key={item}>{item.replace(/^pattern:/, 'パターン: ')}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </form>
+
+      <div className="border-t border-gray-200 p-3 text-[11px] text-gray-600 dark:border-slate-800 dark:text-gray-300">
+        <p className="mb-2 text-xs font-semibold">権限とマスク設定</p>
+        <div className="space-y-2">
+          <div>
+            <span className="block text-[10px] text-gray-500">現在のロール</span>
+            <select
+              value={helpSettings.currentRole}
+              onChange={(event) => handleRoleChange(event.target.value as HelpUserRole)}
+              className="mt-1 w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800"
+            >
+              {Object.entries(ROLE_LABELS).map(([role, label]) => (
+                <option key={role} value={role}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <span className="block text-[10px] text-gray-500">利用を許可するロール</span>
+            <div className="mt-1 space-y-1">
+              {Object.entries(ROLE_LABELS).map(([role, label]) => (
+                <label key={role} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={helpSettings.allowedRoles[role as HelpUserRole]}
+                    onChange={() => handleToggleRolePermission(role as HelpUserRole)}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={helpSettings.maskFileContent}
+              onChange={(event) => updateHelpSettings({ maskFileContent: event.target.checked })}
+            />
+            ファイル内容を常にマスクする
+          </label>
+          <div className="grid grid-cols-1 gap-2">
+            <div>
+              <span className="block text-[10px] text-gray-500">デフォルトのドキュメントID</span>
+              <input
+                type="text"
+                value={helpSettings.defaultDocumentId}
+                onChange={(event) => handleDefaultDocChange('defaultDocumentId', event.target.value)}
+                className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800"
+              />
+            </div>
+            <div>
+              <span className="block text-[10px] text-gray-500">デフォルトのナレッジベースURL</span>
+              <input
+                type="text"
+                value={helpSettings.defaultKnowledgeBaseUrl}
+                onChange={(event) => handleDefaultDocChange('defaultKnowledgeBaseUrl', event.target.value)}
+                className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HelpSidebar;

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React from 'react';
-import { IoFolderOpenOutline, IoGitBranchOutline } from 'react-icons/io5';
+import { IoFolderOpenOutline, IoGitBranchOutline, IoChatbubblesOutline } from 'react-icons/io5';
 
-type ActivityItem = 'explorer' | 'git';
+type ActivityItem = 'explorer' | 'git' | 'help';
 
 interface ActivityBarProps {
   activeItem: ActivityItem | null;
@@ -35,6 +35,15 @@ const ActivityBar: React.FC<ActivityBarProps> = ({ activeItem, onSelect }) => {
         aria-pressed={activeItem === 'git'}
       >
         <IoGitBranchOutline size={20} />
+      </button>
+      <button
+        type="button"
+        className={`${baseButton} mt-2 ${activeItem === 'help' ? activeClass : inactiveClass}`}
+        onClick={() => onSelect('help')}
+        title="ヘルプ"
+        aria-pressed={activeItem === 'help'}
+      >
+        <IoChatbubblesOutline size={20} />
       </button>
     </nav>
   );

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -10,6 +10,7 @@ import {
   IoGitMergeOutline,
   IoGitBranchOutline,
   IoDownloadOutline,
+  IoHelpCircleOutline,
 } from 'react-icons/io5';
 
 interface MainHeaderProps {
@@ -27,6 +28,8 @@ interface MainHeaderProps {
   onToggleGit: () => void;
   isGitPaneVisible: boolean;
   onCloneRepository: () => void;
+  onToggleHelp: () => void;
+  isHelpPaneVisible: boolean;
 }
 
 const MainHeader: React.FC<MainHeaderProps> = ({
@@ -44,6 +47,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleGit,
   isGitPaneVisible,
   onCloneRepository,
+  onToggleHelp,
+  isHelpPaneVisible,
 }) => {
   const isDark = theme === 'dark';
 
@@ -105,6 +110,16 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         aria-label="Toggle Search"
       >
         <IoSearch size={20} />
+      </button>
+      <button
+        className={`p-1 rounded ml-2 ${
+          isHelpPaneVisible ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+        }`}
+        onClick={onToggleHelp}
+        aria-label="Toggle Help"
+        title={`ヘルプパネル ${isHelpPaneVisible ? '表示中' : '非表示'}`}
+      >
+        <IoHelpCircleOutline size={20} />
       </button>
       <button
         className={`p-1 rounded ml-2 ${

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -85,7 +85,12 @@ const MainLayout = () => {
 
   const togglePane = useCallback(
     (pane: keyof typeof paneState) => {
-      if (pane === 'isExplorerVisible' || pane === 'isGitVisible' || pane === 'activeSidebar') {
+      if (
+        pane === 'isExplorerVisible' ||
+        pane === 'isGitVisible' ||
+        pane === 'isHelpVisible' ||
+        pane === 'activeSidebar'
+      ) {
         return;
       }
       updatePaneState({ [pane]: !paneState[pane] });
@@ -99,6 +104,7 @@ const MainLayout = () => {
       activeSidebar: isActive ? null : 'explorer',
       isExplorerVisible: !isActive,
       isGitVisible: false,
+      isHelpVisible: false,
     });
   }, [paneState.activeSidebar, updatePaneState]);
 
@@ -108,6 +114,17 @@ const MainLayout = () => {
       activeSidebar: isActive ? null : 'git',
       isGitVisible: !isActive,
       isExplorerVisible: false,
+      isHelpVisible: false,
+    });
+  }, [paneState.activeSidebar, updatePaneState]);
+
+  const handleToggleHelpPane = useCallback(() => {
+    const isActive = paneState.activeSidebar === 'help';
+    updatePaneState({
+      activeSidebar: isActive ? null : 'help',
+      isHelpVisible: !isActive,
+      isExplorerVisible: false,
+      isGitVisible: false,
     });
   }, [paneState.activeSidebar, updatePaneState]);
 
@@ -434,8 +451,10 @@ const MainLayout = () => {
         onToggleMultiFileAnalysis={handleToggleMultiFile}
         selectedFileCount={selectedFiles.size}
         onToggleGit={handleToggleGitPane}
-        isGitPaneVisible={paneState.activeSidebar === 'git'}
+        isGitPaneVisible={paneState.isGitVisible}
         onCloneRepository={handleOpenGitCloneDialog}
+        onToggleHelp={handleToggleHelpPane}
+        isHelpPaneVisible={paneState.isHelpVisible}
       />
 
       <TabBarDnD />

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -17,6 +17,7 @@ import ActivityBar from '@/components/layout/ActivityBar';
 import GitHistoryView from '@/components/git/GitHistoryView';
 import GitDiffView from '@/components/git/GitDiffView';
 import GitCommitDiffView from '@/components/git/GitCommitDiffView';
+import HelpSidebar from '@/components/help/HelpSidebar';
 
 interface WorkspaceProps {
   paneState: PaneState;
@@ -50,19 +51,24 @@ const Workspace: React.FC<WorkspaceProps> = ({
     if (paneState.isGitVisible) {
       return 'git';
     }
+    if (paneState.isHelpVisible) {
+      return 'help';
+    }
     return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible]);
+  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isHelpVisible]);
 
   const showExplorer = activeSidebar === 'explorer';
   const showGitSidebar = activeSidebar === 'git';
+  const showHelpSidebar = activeSidebar === 'help';
 
   const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'git') => {
+    (sidebar: 'explorer' | 'git' | 'help') => {
       const isActive = activeSidebar === sidebar;
       updatePaneState({
         activeSidebar: isActive ? null : sidebar,
         isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
         isGitVisible: sidebar === 'git' ? !isActive : false,
+        isHelpVisible: sidebar === 'help' ? !isActive : false,
       });
     },
     [activeSidebar, updatePaneState]
@@ -317,6 +323,11 @@ const Workspace: React.FC<WorkspaceProps> = ({
       {showGitSidebar && (
         <div className="w-96 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 overflow-hidden">
           <GitPanel />
+        </div>
+      )}
+      {showHelpSidebar && (
+        <div className="w-96 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 overflow-hidden">
+          <HelpSidebar />
         </div>
       )}
       <div className="flex-1 flex overflow-hidden">

--- a/src/lib/llm/helpClient.ts
+++ b/src/lib/llm/helpClient.ts
@@ -1,0 +1,61 @@
+import type { HelpMessageRole } from '@/types';
+
+export interface HelpApiMessage {
+  role: HelpMessageRole;
+  content: string;
+}
+
+export interface HelpApiRequest {
+  query: string;
+  documentId: string;
+  knowledgeBaseUrl: string;
+  context?: string | null;
+  history?: HelpApiMessage[];
+  maskedFiles?: { path: string; reason: string }[];
+}
+
+export interface HelpApiUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+export interface HelpApiResponse {
+  answer: string;
+  documentId: string;
+  knowledgeBaseUrl: string;
+  usage?: HelpApiUsage | null;
+}
+
+export async function requestHelp(payload: HelpApiRequest): Promise<HelpApiResponse> {
+  const response = await fetch('/api/llm/help', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `ヘルプへの問い合わせに失敗しました。（${response.status}）`;
+    try {
+      const errorPayload = await response.json();
+      if (errorPayload && typeof errorPayload.error === 'string') {
+        message = errorPayload.error;
+      }
+    } catch {
+      // ignore parsing errors
+    }
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+
+  return {
+    answer: typeof data?.answer === 'string' ? data.answer : '',
+    documentId: typeof data?.documentId === 'string' ? data.documentId : payload.documentId,
+    knowledgeBaseUrl:
+      typeof data?.knowledgeBaseUrl === 'string' ? data.knowledgeBaseUrl : payload.knowledgeBaseUrl,
+    usage: data?.usage ?? null,
+  };
+}

--- a/src/lib/llm/helpSanitizer.ts
+++ b/src/lib/llm/helpSanitizer.ts
@@ -1,0 +1,119 @@
+import { HelpUserRole } from '@/types';
+
+export interface HelpFileAttachment {
+  path: string;
+  content: string;
+}
+
+export interface HelpSanitizerOptions {
+  maskFileContent: boolean;
+  userRole: HelpUserRole;
+  allowedRoles: Record<HelpUserRole, boolean>;
+  maxContextLength?: number;
+  additionalPatterns?: RegExp[];
+}
+
+export interface SanitizedHelpRequest {
+  sanitizedQuery: string;
+  context: string | null;
+  maskedFiles: { path: string; reason: string }[];
+  maskedPatterns: string[];
+  blocked: boolean;
+  blockReason?: string;
+}
+
+const DEFAULT_SENSITIVE_PATTERNS: RegExp[] = [
+  /sk-[a-zA-Z0-9]{32,}/g, // OpenAI keys
+  /(AIza[0-9A-Za-z\-_]{35})/g, // Google API keys
+  /(xox[pbar]-[0-9A-Za-z-]{10,})/g, // Slack tokens
+  /(?<=password\s*[=:]\s*)(['"])?.+?\1(?=\s|$)/gi,
+  /(?<=secret\s*[=:]\s*)(['"])?.+?\1(?=\s|$)/gi,
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]+?-----END [A-Z ]+PRIVATE KEY-----/g,
+];
+
+function maskSensitiveSegments(text: string, patterns: RegExp[]): { sanitized: string; matches: string[] } {
+  if (!text) {
+    return { sanitized: '', matches: [] };
+  }
+
+  let sanitized = text;
+  const matches: string[] = [];
+
+  patterns.forEach((pattern) => {
+    sanitized = sanitized.replace(pattern, (match) => {
+      const label = `pattern:${pattern.source}`;
+      if (label && !matches.includes(label)) {
+        matches.push(label);
+      }
+      return '[MASKED]';
+    });
+  });
+
+  return { sanitized, matches };
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength - 20)}\n...[truncated]`;
+}
+
+export function sanitizeHelpRequest(
+  input: { query: string; files?: HelpFileAttachment[] },
+  options: HelpSanitizerOptions,
+): SanitizedHelpRequest {
+  const { allowedRoles, userRole, maskFileContent, maxContextLength = 4000, additionalPatterns = [] } = options;
+  const patterns = [...DEFAULT_SENSITIVE_PATTERNS, ...additionalPatterns];
+  const roleAllowed = allowedRoles?.[userRole];
+
+  const { sanitized: sanitizedQuery, matches: queryMatches } = maskSensitiveSegments(input.query ?? '', patterns);
+
+  if (!roleAllowed) {
+    return {
+      sanitizedQuery,
+      context: null,
+      maskedFiles: [],
+      maskedPatterns: queryMatches,
+      blocked: true,
+      blockReason: '現在の権限ではヘルプ機能を利用できません。',
+    };
+  }
+
+  const maskedFiles: { path: string; reason: string }[] = [];
+  const maskedPatterns = [...queryMatches];
+
+  const fileBlocks = (input.files ?? []).map((file) => {
+    const path = file.path ?? 'unknown';
+    const rawContent = file.content ?? '';
+
+    if (maskFileContent) {
+      maskedFiles.push({ path, reason: 'マスク設定により非表示' });
+      return `## File: ${path}\n[マスク済みコンテンツ]`;
+    }
+
+    const { sanitized, matches } = maskSensitiveSegments(rawContent, patterns);
+    matches.forEach((match) => {
+      if (!maskedPatterns.includes(match)) {
+        maskedPatterns.push(match);
+      }
+    });
+
+    const limited = truncate(sanitized, maxContextLength);
+    return `## File: ${path}\n${limited}`;
+  });
+
+  const context = fileBlocks.length > 0 ? fileBlocks.join('\n\n') : null;
+
+  return {
+    sanitizedQuery,
+    context,
+    maskedFiles,
+    maskedPatterns,
+    blocked: false,
+  };
+}
+
+export const helpSanitizerDefaults = {
+  patterns: DEFAULT_SENSITIVE_PATTERNS,
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,7 +79,7 @@ export interface EditorSettings {
 
 // パネル表示状態に関する型定義
 export interface PaneState {
-  activeSidebar: 'explorer' | 'git' | null;
+  activeSidebar: 'explorer' | 'git' | 'help' | null;
   isExplorerVisible: boolean;
   isEditorVisible: boolean;
   isPreviewVisible: boolean;
@@ -87,6 +87,7 @@ export interface PaneState {
   isSearchVisible: boolean;
   isAnalysisVisible: boolean;
   isGitVisible: boolean;
+  isHelpVisible: boolean;
 }
 
 // コンテキストメニューに関する型定義
@@ -186,4 +187,39 @@ export interface SqlNotebookCell {
   executedAt: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export type HelpMessageRole = 'user' | 'assistant';
+
+export interface HelpMessageMetadata {
+  maskedFiles?: { path: string; reason: string }[];
+  maskedPatterns?: string[];
+}
+
+export interface HelpMessage {
+  id: string;
+  role: HelpMessageRole;
+  content: string;
+  createdAt: string;
+  metadata?: HelpMessageMetadata;
+}
+
+export interface HelpThread {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: HelpMessage[];
+  documentId?: string;
+  knowledgeBaseUrl?: string;
+}
+
+export type HelpUserRole = 'viewer' | 'editor' | 'admin';
+
+export interface HelpSettings {
+  currentRole: HelpUserRole;
+  allowedRoles: Record<HelpUserRole, boolean>;
+  maskFileContent: boolean;
+  defaultDocumentId: string;
+  defaultKnowledgeBaseUrl: string;
 }


### PR DESCRIPTION
## Summary
- add an /api/llm/help endpoint that forwards knowledge base-aware prompts to ChatGPT
- implement a help sidebar with chat history, role-based permissions, and document metadata controls
- add a sanitizer utility and store slice to mask sensitive content before sending requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc7126f03c832fb238095b3a7fa492