### PR TITLE
Gracefully handle missing OpenAI key in Mermaid generator

### DIFF
--- a/src/app/api/llm/status/route.ts
+++ b/src/app/api/llm/status/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const hasOpenAiApiKey =
+    typeof process.env.OPENAI_API_KEY === 'string' && process.env.OPENAI_API_KEY.trim().length > 0;
+
+  return NextResponse.json({
+    hasOpenAiApiKey,
+  });
+}


### PR DESCRIPTION
## Summary
- add an llm status endpoint to report whether the OpenAI API key is configured
- surface the configuration status in the Mermaid template dialog and disable AI generation when unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe466eecc832f9ae121bc7c297bc0