### PR TITLE
Fix gitGraph header syntax for Mermaid diagrams

### DIFF
--- a/src/lib/mermaid/__tests__/gitGraphParser.test.ts
+++ b/src/lib/mermaid/__tests__/gitGraphParser.test.ts
@@ -3,7 +3,7 @@ import { parseMermaidSource } from '../parser';
 
 describe('parseGitGraph branch inheritance', () => {
   it('connects checkout edge from source branch commit to new branch first commit', () => {
-    const source = `gitGraph LR:
+    const source = `gitGraph LR
   commit id: "A"
   branch develop
   branch feature
@@ -35,7 +35,7 @@ describe('parseGitGraph branch inheritance', () => {
   });
 
   it('sets branch metadata on commits according to the active branch', () => {
-    const source = `gitGraph LR:
+    const source = `gitGraph LR
   commit id: "A"
   commit id: "B"
   branch "feature/login"
@@ -79,7 +79,7 @@ describe('parseGitGraph branch inheritance', () => {
   });
 
   it('links branch creation and checkout command nodes with dedicated edges', () => {
-    const source = `gitGraph LR:
+    const source = `gitGraph LR
   commit id: "A"
   branch feature
   checkout feature`;
@@ -118,7 +118,7 @@ describe('parseGitGraph branch inheritance', () => {
   });
 
   it('connects merge commands to the latest commits of participating branches', () => {
-    const source = `gitGraph LR:
+    const source = `gitGraph LR
   commit id: "A"
   branch feature
   checkout feature

--- a/src/lib/mermaid/diagramDefinitions.ts
+++ b/src/lib/mermaid/diagramDefinitions.ts
@@ -732,7 +732,7 @@ export const diagramDefinitions: Record<MermaidDiagramType, MermaidDiagramDefini
       },
     ],
     defaultConfig: { type: 'gitGraph', orientation: 'LR' },
-    defaultTemplate: `gitGraph LR:
+    defaultTemplate: `gitGraph LR
   commit id: "A"
   commit id: "B"
   branch feature

--- a/src/lib/mermaid/serializer.ts
+++ b/src/lib/mermaid/serializer.ts
@@ -386,7 +386,7 @@ const serializeGitGraph = (model: MermaidGraphModel): MermaidSerializationResult
   const config = model.config.type === 'gitGraph' ? model.config : diagramDefinitions.gitGraph.defaultConfig;
   const warnings: string[] = [];
   const orientation = config.orientation ?? 'LR';
-  const lines: string[] = [`gitGraph ${orientation}:`];
+  const lines: string[] = [`gitGraph ${orientation}`];
 
   const orderMap = new Map<string, number>();
   model.nodes.forEach((node, index) => {


### PR DESCRIPTION
## Summary
- emit gitGraph headers without a trailing colon when serializing or seeding templates so Mermaid accepts generated diagrams
- align gitGraph parser tests with the updated header format to ensure continued coverage of branch and merge handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dce83de37c832fb4c72cc2eaf641cd