### PR TITLE
Lazy load GIS parsers to resolve build failure

### DIFF
--- a/src/components/analysis/DataAnalysis.tsx
+++ b/src/components/analysis/DataAnalysis.tsx
@@ -631,7 +631,7 @@ const DataAnalysis: React.FC<DataAnalysisProps> = ({ tabId }) => {
         }
 
         case 'kml': {
-          const kmlResult = parseKmlContent(content);
+          const kmlResult = await parseKmlContent(content);
           if (kmlResult.error) {
             setError(kmlResult.error);
             setLoading(false);
@@ -646,7 +646,7 @@ const DataAnalysis: React.FC<DataAnalysisProps> = ({ tabId }) => {
         case 'kmz': {
           try {
             const buffer = await loadBinaryContent();
-            const kmzResult = parseKmzContent(buffer);
+            const kmzResult = await parseKmzContent(buffer);
             if (kmzResult.error) {
               setError(kmzResult.error);
               setLoading(false);
@@ -4941,18 +4941,6 @@ const DataAnalysis: React.FC<DataAnalysisProps> = ({ tabId }) => {
         {/* SQLクエリタブ */}
         {activeTab === 'query' && (
           <div className="h-full flex flex-col">
-            <div className="flex justify-end p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-              <button
-                className="px-3 py-1 flex items-center text-sm text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
-                onClick={toggleDisplayMode}
-                title={editorSettings.dataDisplayMode === 'flat' ? "階層表示に切替" : "フラット表示に切替"}
-              >
-                <IoLayersOutline className="mr-1" size={16} />
-                <span className="text-sm">
-                  {editorSettings.dataDisplayMode === 'flat' ? '階層表示' : 'フラット表示'}
-                </span>
-              </button>
-            </div>
             <div className="flex-1 overflow-auto">
               {renderQueryResult()}
             </div>

--- a/src/components/analysis/MultiFileAnalysis.tsx
+++ b/src/components/analysis/MultiFileAnalysis.tsx
@@ -652,7 +652,7 @@ const MultiFileAnalysis: React.FC<MultiFileAnalysisProps> = ({ onClose }) => {
               break;
             }
             case 'kml': {
-              const kmlResult = parseKmlContent(textContent ?? '');
+              const kmlResult = await parseKmlContent(textContent ?? '');
               if (kmlResult.error) throw new Error(kmlResult.error);
               data = kmlResult.rows;
               break;
@@ -661,7 +661,7 @@ const MultiFileAnalysis: React.FC<MultiFileAnalysisProps> = ({ onClose }) => {
               if (!binaryContent) {
                 binaryContent = await file.arrayBuffer();
               }
-              const kmzResult = parseKmzContent(binaryContent);
+              const kmzResult = await parseKmzContent(binaryContent);
               if (kmzResult.error) throw new Error(kmzResult.error);
               data = kmzResult.rows;
               break;

--- a/src/components/preview/DataPreview.tsx
+++ b/src/components/preview/DataPreview.tsx
@@ -521,7 +521,7 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
         }
 
         case 'kml': {
-          const kmlResult = parseKmlContent((content as string) ?? '');
+          const kmlResult = await parseKmlContent((content as string) ?? '');
           applyGisResult(kmlResult);
           break;
         }
@@ -529,7 +529,7 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
         case 'kmz': {
           try {
             const buffer = await loadBinaryFromTab();
-            const kmzResult = parseKmzContent(buffer);
+            const kmzResult = await parseKmzContent(buffer);
             if (!applyGisResult(kmzResult)) {
               setLoading(false);
               return;


### PR DESCRIPTION
## Summary
- lazy load the KML/KMZ and shapefile parsers so their dependencies are dynamically imported with clearer error messaging when missing
- update analysis and preview workflows to await the asynchronous GIS parsing helpers, keeping the single display mode toggle intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2f4590bc832f982cbd2a81fdf3b2