### PR TITLE
Improve GIS mode activation and sidebar UX

### DIFF
--- a/src/components/analysis/GisAnalysisView.tsx
+++ b/src/components/analysis/GisAnalysisView.tsx
@@ -1248,7 +1248,7 @@ const GisAnalysisView: React.FC<{ tabId: string }> = ({ tabId }) => {
         </div>
       </main>
 
-      <aside className="w-80 flex-shrink-0 border-l border-gray-200 bg-white/80 p-4 dark:border-gray-800 dark:bg-gray-900/60">
+      <aside className="w-80 flex-shrink-0 border-l border-gray-200 bg-white/80 p-4 overflow-y-auto dark:border-gray-800 dark:bg-gray-900/60">
         <div className="mb-4">
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200">シンボル設定</h2>
           <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -12,7 +12,6 @@ import {
   IoDownloadOutline,
   IoKeyOutline,
   IoHelpCircleOutline,
-  IoGlobeOutline,
 } from 'react-icons/io5';
 
 interface MainHeaderProps {
@@ -33,9 +32,6 @@ interface MainHeaderProps {
   onToggleHelp: () => void;
   isHelpPaneVisible: boolean;
   onOpenLlmSettings: () => void;
-  isGisData: boolean;
-  isGisModeActive: boolean;
-  onToggleGisMode: () => void;
 }
 
 const MainHeader: React.FC<MainHeaderProps> = ({
@@ -56,18 +52,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleHelp,
   isHelpPaneVisible,
   onOpenLlmSettings,
-  isGisData,
-  isGisModeActive,
-  onToggleGisMode,
 }) => {
   const isDark = theme === 'dark';
-
-  const canToggleGisMode = isGisData || isGisModeActive;
-  const gisButtonLabel = isGisModeActive
-    ? 'GIS分析モードを終了'
-    : isGisData
-      ? 'GIS分析モードを表示'
-      : 'GIS対応ファイルを開くと利用できます';
 
   return (
     <header className="flex items-center px-4 h-12 bg-white border-b border-gray-300 dark:bg-gray-900 dark:border-gray-700">
@@ -135,72 +121,6 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         title="OpenAI APIキー設定"
       >
         <IoKeyOutline size={20} />
-      </button>
-      {isGisData && (
-        <button
-          className={`p-1 rounded ml-2 ${
-            isGisModeActive ? 'bg-teal-100 text-teal-700' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-          }`}
-          onClick={onToggleGisMode}
-          aria-label="Toggle GIS Analysis Mode"
-          title={`GIS分析モードを${isGisModeActive ? '終了' : '表示'}`}
-        >
-          <IoGlobeOutline size={20} />
-        </button>
-      )}
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
-      </button>
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
-      </button>
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
       </button>
       <button
         className={`p-1 rounded ml-2 ${

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -233,13 +233,6 @@ const MainLayout = () => {
     setViewMode(activeTabId, nextMode);
   }, [activeTabId, activeTabViewMode, fileTypeFlags.isGisData, setViewMode]);
 
-  const handleToggleGisAnalysisMode = useCallback(() => {
-    if (!activeTabId || !fileTypeFlags.isGisData) return;
-
-    const nextMode = activeTabViewMode === 'gis-analysis' ? 'editor' : 'gis-analysis';
-    setViewMode(activeTabId, nextMode);
-  }, [activeTabId, activeTabViewMode, fileTypeFlags.isGisData, setViewMode]);
-
   const handleConfirmNewFile = useCallback(
     async (fileName: string) => {
       setShowNewFileDialog(false);
@@ -491,9 +484,6 @@ const MainLayout = () => {
         onToggleHelp={handleToggleHelpPane}
         isHelpPaneVisible={paneState.isHelpVisible}
         onOpenLlmSettings={() => setShowLlmSettingsDialog(true)}
-        isGisData={fileTypeFlags.isGisData}
-        isGisModeActive={activeTabViewMode === 'gis-analysis'}
-        onToggleGisMode={handleToggleGisAnalysisMode}
       />
 
       <TabBarDnD />

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -39,49 +39,10 @@ const Workspace: React.FC<WorkspaceProps> = ({
   onCloseMultiFileAnalysis,
 }) => {
   const updatePaneState = useEditorStore((state) => state.updatePaneState);
+  const setViewMode = useEditorStore((state) => state.setViewMode);
   const editorRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const [isScrollSyncEnabled, setIsScrollSyncEnabled] = useState(false);
-
-  const activeSidebar = useMemo(() => {
-    if (paneState.activeSidebar !== undefined && paneState.activeSidebar !== null) {
-      return paneState.activeSidebar;
-    }
-    if (paneState.isExplorerVisible) {
-      return 'explorer';
-    }
-    if (paneState.isGitVisible) {
-      return 'git';
-    }
-    if (paneState.isGisVisible) {
-      return 'gis';
-    }
-    if (paneState.isHelpVisible) {
-      return 'help';
-    }
-    return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
-
-  const showExplorer = activeSidebar === 'explorer';
-  const showGitSidebar = activeSidebar === 'git';
-  const showGisSidebar = activeSidebar === 'gis';
-  const showHelpSidebar = activeSidebar === 'help';
-
-  const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
-      const isActive = activeSidebar === sidebar;
-      updatePaneState({
-        activeSidebar: isActive ? null : sidebar,
-        isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
-        isGisVisible: sidebar === 'gis' ? !isActive : false,
-        isGitVisible: sidebar === 'git' ? !isActive : false,
-        isHelpVisible: sidebar === 'help' ? !isActive : false,
-      });
-    },
-  [activeSidebar, updatePaneState]
-  );
-
-  const showSearchPanel = paneState.isSearchVisible;
 
   const {
     isMarkdown,
@@ -123,6 +84,56 @@ const Workspace: React.FC<WorkspaceProps> = ({
       isGisData: gisData,
     };
   }, [activeTab]);
+
+  const activeSidebar = useMemo(() => {
+    if (paneState.activeSidebar !== undefined && paneState.activeSidebar !== null) {
+      return paneState.activeSidebar;
+    }
+    if (paneState.isExplorerVisible) {
+      return 'explorer';
+    }
+    if (paneState.isGitVisible) {
+      return 'git';
+    }
+    if (paneState.isGisVisible) {
+      return 'gis';
+    }
+    if (paneState.isHelpVisible) {
+      return 'help';
+    }
+    return null;
+  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
+
+  const showExplorer = activeSidebar === 'explorer';
+  const showGitSidebar = activeSidebar === 'git';
+  const showGisSidebar = activeSidebar === 'gis';
+  const showHelpSidebar = activeSidebar === 'help';
+
+  const handleSidebarSelect = useCallback(
+    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
+      const isActive = activeSidebar === sidebar;
+      updatePaneState({
+        activeSidebar: isActive ? null : sidebar,
+        isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
+        isGisVisible: sidebar === 'gis' ? !isActive : false,
+        isGitVisible: sidebar === 'git' ? !isActive : false,
+        isHelpVisible: sidebar === 'help' ? !isActive : false,
+      });
+
+      if (sidebar === 'gis' && activeTabId && isGisData) {
+        if (isActive) {
+          if (activeTabViewMode === 'gis-analysis') {
+            setViewMode(activeTabId, 'editor');
+          }
+        } else {
+          setViewMode(activeTabId, 'gis-analysis');
+        }
+      }
+    },
+    [activeSidebar, activeTabId, activeTabViewMode, isGisData, setViewMode, updatePaneState]
+  );
+
+  const showSearchPanel = paneState.isSearchVisible;
 
   const handleEditorScroll = useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- remove the duplicate GIS buttons from the main header
- switch the active tab into GIS analysis mode when the GIS activity icon is selected
- add vertical scrolling to the GIS analysis settings sidebar so the menu fits

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dde563eb98832f95cd5d04dba51ed4