### PR TITLE
feat: support multi-file GIS overlays

### DIFF
--- a/src/components/analysis/GisSidebar.tsx
+++ b/src/components/analysis/GisSidebar.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
-import {
-  IoChevronDown,
-  IoChevronForward,
-  IoDocumentOutline,
-  IoFolderOutline,
-  IoStatsChartOutline,
-} from 'react-icons/io5';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IoChevronDown, IoChevronForward, IoDocumentOutline, IoSparkles, IoStatsChartOutline, IoWarningOutline } from 'react-icons/io5';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 import { useEditorStore } from '@/store/editorStore';
 import { useGisAnalysisStore } from '@/store/gisStore';
@@ -15,22 +11,13 @@ import { getFileType } from '@/lib/editorUtils';
 import type { FileTreeItem } from '@/types';
 import type { GisFileType } from '@/lib/gisFileTypes';
 import { GIS_FILE_TYPES } from '@/lib/gisFileTypes';
+import type { LlmReportResponse } from '@/lib/llm/analysisSummarizer';
 
-interface GisDirectoryNode {
-  kind: 'directory';
-  name: string;
+interface GisFileEntry {
   path: string;
-  children: GisTreeNode[];
-}
-
-interface GisFileNode {
-  kind: 'file';
   name: string;
-  path: string;
   fileType: GisFileType;
 }
-
-type GisTreeNode = GisDirectoryNode | GisFileNode;
 
 const isSupportedGisType = (value: string): value is GisFileType => {
   return (GIS_FILE_TYPES as readonly string[]).includes(value);
@@ -44,100 +31,83 @@ const isGisFile = (item: FileTreeItem) => {
   return isSupportedGisType(type);
 };
 
-const buildGisTree = (root: FileTreeItem | null): GisTreeNode[] => {
+const collectGisFiles = (root: FileTreeItem | null): GisFileEntry[] => {
   if (!root) {
     return [];
   }
 
-  const traverse = (node: FileTreeItem): GisTreeNode | null => {
-    if (node.isDirectory) {
-      const children = (node.children ?? [])
-        .map(traverse)
-        .filter((child): child is GisTreeNode => Boolean(child));
+  const files: GisFileEntry[] = [];
+  const stack: FileTreeItem[] = [root];
 
-      if (children.length === 0) {
-        return null;
-      }
-
-      return {
-        kind: 'directory',
-        name: node.name,
-        path: node.path,
-        children,
-      };
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
     }
 
-    if (isGisFile(node)) {
-      const type = getFileType(node.name);
-      if (!isSupportedGisType(type)) {
-        return null;
-      }
-      return {
-        kind: 'file',
-        name: node.name,
-        path: node.path,
-        fileType: type,
-      };
+    if (current.isDirectory) {
+      current.children?.forEach((child) => stack.push(child));
+      continue;
     }
 
-    return null;
-  };
-
-  if (root.isDirectory) {
-    return (root.children ?? [])
-      .map(traverse)
-      .filter((child): child is GisTreeNode => Boolean(child));
+    if (isGisFile(current)) {
+      const fileType = getFileType(current.name);
+      if (isSupportedGisType(fileType)) {
+        files.push({
+          path: current.path,
+          name: current.name,
+          fileType: fileType,
+        });
+      }
+    }
   }
 
-  const single = traverse(root);
-  return single ? [single] : [];
-};
-
-const ensureExpandedAncestors = (path: string): string[] => {
-  const segments = path.split('/');
-  const expanded: string[] = [];
-  let accumulator = '';
-  segments.forEach((segment) => {
-    if (!segment) {
-      return;
-    }
-    accumulator = accumulator ? `${accumulator}/${segment}` : segment;
-    expanded.push(accumulator);
-  });
-  return expanded;
+  files.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+  return files;
 };
 
 const GisSidebar: React.FC = () => {
   const rootFileTree = useEditorStore((state) => state.rootFileTree);
   const columnCache = useGisAnalysisStore((state) => state.columnCache);
-  const selectedFilePath = useGisAnalysisStore((state) => state.selectedFilePath);
-  const selectedColumn = useGisAnalysisStore((state) => state.selectedColumn);
-  const setSelectedFilePath = useGisAnalysisStore((state) => state.setSelectedFilePath);
+  const selectedFilePaths = useGisAnalysisStore((state) => state.selectedFilePaths);
+  const activeFilePath = useGisAnalysisStore((state) => state.activeFilePath);
+  const selectedColumns = useGisAnalysisStore((state) => state.selectedColumns);
+  const toggleSelectedFilePath = useGisAnalysisStore((state) => state.toggleSelectedFilePath);
+  const setActiveFilePath = useGisAnalysisStore((state) => state.setActiveFilePath);
   const setSelectedColumn = useGisAnalysisStore((state) => state.setSelectedColumn);
+  const analysisSummary = useGisAnalysisStore((state) => state.analysisSummary);
 
-  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
+  const [aiPrompt, setAiPrompt] = useState('');
+  const [aiResult, setAiResult] = useState<LlmReportResponse | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
 
-  const tree = useMemo(() => buildGisTree(rootFileTree), [rootFileTree]);
+  const files = useMemo(() => collectGisFiles(rootFileTree), [rootFileTree]);
+  const fileMap = useMemo(() => new Map(files.map((file) => [file.path, file])), [files]);
 
   useEffect(() => {
-    if (!selectedFilePath) {
+    if (!activeFilePath) {
       return;
     }
-    setExpandedNodes((previous) => {
+    setExpandedFiles((previous) => {
+      if (previous.has(activeFilePath)) {
+        return previous;
+      }
       const next = new Set(previous);
-      ensureExpandedAncestors(selectedFilePath).forEach((ancestor) => next.add(ancestor));
+      next.add(activeFilePath);
       return next;
     });
-  }, [selectedFilePath]);
+  }, [activeFilePath]);
 
   useEffect(() => {
-    if (tree.length === 0) {
-      setExpandedNodes(new Set());
+    if (files.length === 0) {
+      setExpandedFiles(new Set());
     }
-  }, [tree]);
+  }, [files]);
 
-  const toggleNode = (path: string) => {
-    setExpandedNodes((previous) => {
+  const toggleFileExpansion = useCallback((path: string) => {
+    setExpandedFiles((previous) => {
       const next = new Set(previous);
       if (next.has(path)) {
         next.delete(path);
@@ -146,126 +116,277 @@ const GisSidebar: React.FC = () => {
       }
       return next;
     });
-  };
+  }, []);
 
-  const handleSelectFile = (path: string) => {
-    setSelectedFilePath(path);
-    setExpandedNodes((previous) => {
-      const next = new Set(previous);
-      ensureExpandedAncestors(path).forEach((ancestor) => next.add(ancestor));
-      next.add(path);
-      return next;
-    });
-  };
+  const handleSelectColumn = useCallback(
+    (path: string, column: string) => {
+      setSelectedColumn(path, column);
+    },
+    [setSelectedColumn],
+  );
 
-  const handleSelectColumn = (column: string) => {
-    setSelectedColumn(column);
-  };
+  const datasetDisplayName = useMemo(() => {
+    if (analysisSummary?.metadata.datasetName) {
+      return analysisSummary.metadata.datasetName;
+    }
+    if (!activeFilePath) {
+      return null;
+    }
+    const file = fileMap.get(activeFilePath);
+    if (file) {
+      return file.name;
+    }
+    const segments = activeFilePath.split('/').filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : activeFilePath;
+  }, [analysisSummary, activeFilePath, fileMap]);
 
-  const renderNode = (node: GisTreeNode, depth = 0) => {
-    if (node.kind === 'directory') {
-      const isExpanded = expandedNodes.has(node.path);
-      return (
-        <div key={node.path}>
-          <button
-            type="button"
-            onClick={() => toggleNode(node.path)}
-            className="flex w-full items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            style={{ paddingLeft: depth * 16 + 8 }}
-          >
-            {isExpanded ? <IoChevronDown size={16} /> : <IoChevronForward size={16} />}
-            <IoFolderOutline size={16} />
-            <span>{node.name}</span>
-          </button>
-          {isExpanded && node.children.length > 0 && (
-            <div>{node.children.map((child) => renderNode(child, depth + 1))}</div>
-          )}
-        </div>
-      );
+  const canRequestAiInsight = useMemo(() => {
+    return Boolean(analysisSummary && analysisSummary.metadata.rowCount > 0);
+  }, [analysisSummary]);
+
+  useEffect(() => {
+    setAiResult(null);
+    setAiError(null);
+  }, [analysisSummary]);
+
+  const handleRequestAiInsight = useCallback(async () => {
+    if (!analysisSummary || aiLoading) {
+      return;
     }
 
-    const isExpanded = expandedNodes.has(node.path);
-    const isSelected = selectedFilePath === node.path;
-    const columns = columnCache[node.path] ?? [];
-    const showColumns = (isExpanded || isSelected) && columns.length > 0;
+    setAiLoading(true);
+    setAiError(null);
 
+    try {
+      const trimmedPrompt = aiPrompt.trim();
+      const response = await fetch('/api/llm/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          summary: analysisSummary,
+          customInstruction: trimmedPrompt.length > 0 ? trimmedPrompt : undefined,
+        }),
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok || !payload) {
+        const message =
+          payload && typeof payload === 'object' && 'error' in payload && typeof (payload as any).error === 'string'
+            ? (payload as { error: string }).error
+            : `GIS分析レポートの生成に失敗しました。（${response.status}）`;
+        throw new Error(message);
+      }
+
+      if (
+        typeof payload !== 'object' ||
+        payload === null ||
+        typeof (payload as Record<string, unknown>).markdown !== 'string' ||
+        !Array.isArray((payload as Record<string, unknown>).bulletSummary)
+      ) {
+        throw new Error('ChatGPTから有効な分析結果を取得できませんでした。');
+      }
+
+      setAiResult(payload as LlmReportResponse);
+    } catch (error) {
+      console.error('GIS sidebar AI analysis error:', error);
+      const message = error instanceof Error ? error.message : 'GIS分析レポートの生成に失敗しました。';
+      setAiError(message);
+      setAiResult(null);
+    } finally {
+      setAiLoading(false);
+    }
+  }, [aiLoading, aiPrompt, analysisSummary]);
+
+  if (files.length === 0) {
     return (
-      <div key={node.path}>
-        <button
-          type="button"
-          onClick={() => {
-            if (isExpanded) {
-              toggleNode(node.path);
-            } else {
-              setExpandedNodes((previous) => {
-                const next = new Set(previous);
-                next.add(node.path);
-                return next;
-              });
-            }
-            handleSelectFile(node.path);
-          }}
-          className={`flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors ${
-            isSelected
-              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200'
-              : 'hover:bg-gray-100 text-gray-700 dark:hover:bg-gray-800 dark:text-gray-200'
-          }`}
-          style={{ paddingLeft: depth * 16 + 8 }}
-        >
-          {showColumns ? <IoChevronDown size={16} /> : <IoChevronForward size={16} />}
-          <IoDocumentOutline size={16} />
-          <span className="flex-1 truncate">{node.name}</span>
-          <span className="text-xs uppercase text-gray-400">{node.fileType}</span>
-        </button>
-        {isSelected && columns.length === 0 && (
-          <div className="pl-10 pr-4 text-xs text-gray-500 dark:text-gray-400">
-            カラム情報は解析が完了すると表示されます。
+      <div className="flex h-full flex-col bg-gray-50/80 dark:bg-gray-900/40">
+        <div className="flex-1 overflow-y-auto p-4 text-sm text-gray-500 dark:text-gray-400">
+          GIS対応ファイルが見つかりません。エクスプローラからGeoJSONやKMLなどのファイルを追加してください。
+        </div>
+        <div className="border-t border-gray-200 bg-white/80 p-4 text-xs text-gray-600 dark:border-gray-800 dark:bg-gray-900/60 dark:text-gray-300">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+            <IoSparkles size={16} />
+            <span>ChatGPT分析</span>
           </div>
-        )}
-        {showColumns && (
-          <ul className="space-y-1 py-2">
-            {columns.map((column) => {
-              const isColumnSelected = column === selectedColumn;
-              return (
-                <li key={`${node.path}:${column}`}>
-                  <button
-                    type="button"
-                    onClick={() => handleSelectColumn(column)}
-                    className={`ml-9 flex w-[calc(100%-2.25rem)] items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors ${
-                      isColumnSelected
-                        ? 'bg-blue-500 text-white'
-                        : 'text-gray-600 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
-                    }`}
-                  >
-                    <IoStatsChartOutline size={14} />
-                    <span className="truncate">{column}</span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-    );
-  };
-
-  if (tree.length === 0) {
-    return (
-      <div className="h-full overflow-y-auto bg-gray-50/80 p-4 text-sm text-gray-500 dark:bg-gray-900/40 dark:text-gray-400">
-        GIS対応ファイルが見つかりません。エクスプローラからGeoJSONやKMLなどのファイルを追加してください。
+          <p className="mt-2 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">
+            地図に表示するGISデータを読み込むと、AIが特徴や注目ポイントを解説してくれます。
+          </p>
+          <p className="mt-2 flex items-start gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+            <IoWarningOutline size={14} className="mt-0.5 flex-shrink-0" />
+            まずはGeoJSONやShapefileなどの対応データを追加し、地図にプロットしてください。
+          </p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-y-auto bg-gray-50/80 dark:bg-gray-900/40">
+    <div className="flex h-full flex-col bg-gray-50/80 dark:bg-gray-900/40">
       <div className="border-b border-gray-200 px-4 py-3 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:border-gray-800 dark:text-gray-300">
         GISデータ
       </div>
-      <div className="divide-y divide-gray-200 dark:divide-gray-800">
-        {tree.map((node) => (
-          <div key={node.path}>{renderNode(node)}</div>
-        ))}
+      <div className="flex-1 overflow-y-auto">
+        <div className="divide-y divide-gray-200 dark:divide-gray-800">
+          {files.map((file) => {
+            const isSelected = selectedFilePaths.includes(file.path);
+            const isActive = activeFilePath === file.path;
+            const isExpanded = expandedFiles.has(file.path);
+            const columns = columnCache[file.path] ?? [];
+            const selectedColumn = selectedColumns[file.path] ?? null;
+            const showColumns = isExpanded && columns.length > 0;
+
+            return (
+              <div key={file.path} className="px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleFileExpansion(file.path)}
+                    className="rounded p-1 text-gray-500 transition hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+                    aria-label={showColumns ? 'カラム一覧を閉じる' : 'カラム一覧を開く'}
+                  >
+                    {showColumns ? <IoChevronDown size={16} /> : <IoChevronForward size={16} />}
+                  </button>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    checked={isSelected}
+                    onChange={() => toggleSelectedFilePath(file.path)}
+                    aria-label={`${file.name} を地図に表示`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setActiveFilePath(file.path)}
+                    className={`flex flex-1 items-center gap-2 rounded px-2 py-1 text-left text-sm transition-colors ${
+                      isActive
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200'
+                        : 'hover:bg-gray-200 text-gray-700 dark:hover:bg-gray-800 dark:text-gray-200'
+                    }`}
+                  >
+                    <IoDocumentOutline size={16} />
+                    <span className="flex-1 truncate">{file.name}</span>
+                    <span className="text-xs uppercase text-gray-400">{file.fileType}</span>
+                  </button>
+                </div>
+                {isSelected && columns.length === 0 && (
+                  <div className="ml-7 mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    カラム情報は解析が完了すると表示されます。
+                  </div>
+                )}
+                {showColumns && (
+                  <ul className="ml-7 mt-2 space-y-1">
+                    {columns.map((column) => {
+                      const isColumnSelected = column === selectedColumn;
+                      return (
+                        <li key={`${file.path}:${column}`}>
+                          <button
+                            type="button"
+                            onClick={() => handleSelectColumn(file.path, column)}
+                            className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors ${
+                              isColumnSelected
+                                ? 'bg-blue-500 text-white'
+                                : 'text-gray-600 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
+                            }`}
+                          >
+                            <IoStatsChartOutline size={14} />
+                            <span className="truncate">{column}</span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="border-t border-gray-200 bg-white/80 p-4 text-xs text-gray-600 dark:border-gray-800 dark:bg-gray-900/60 dark:text-gray-300">
+        <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+          <IoSparkles size={16} />
+          <span>ChatGPT分析</span>
+        </div>
+        <p className="mt-2 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">
+          現在のマップに基づいて、注目ポイントや活用のヒントをAIが要約します。
+        </p>
+
+        <div className="mt-3 rounded border border-gray-200 bg-white/70 px-3 py-2 text-[11px] text-gray-600 shadow-sm dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-300">
+          <div className="text-[11px] font-medium text-gray-700 dark:text-gray-200">対象データ</div>
+          <div className="mt-1 truncate text-[11px] text-gray-500 dark:text-gray-400">
+            {datasetDisplayName ?? '未選択'}
+          </div>
+          {analysisSummary && (
+            <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-gray-500 dark:text-gray-400">
+              <span>行数: {analysisSummary.metadata.rowCount.toLocaleString('ja-JP')}</span>
+              <span>列数: {analysisSummary.metadata.columnCount.toLocaleString('ja-JP')}</span>
+            </div>
+          )}
+        </div>
+
+        <label className="mt-3 block text-[11px] font-medium text-gray-600 dark:text-gray-300" htmlFor="gis-sidebar-ai-prompt">
+          追加で伝えたいこと（任意）
+        </label>
+        <textarea
+          id="gis-sidebar-ai-prompt"
+          value={aiPrompt}
+          onChange={(event) => setAiPrompt(event.target.value)}
+          rows={3}
+          placeholder="例: 特定の自治体ごとの傾向を教えてほしい"
+          className="mt-1 w-full rounded border border-gray-200 bg-white p-2 text-[11px] text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-400"
+        />
+
+        <button
+          type="button"
+          onClick={() => {
+            void handleRequestAiInsight();
+          }}
+          disabled={!canRequestAiInsight || aiLoading}
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:disabled:bg-blue-800/60"
+        >
+          {aiLoading ? (
+            <>
+              <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
+              生成中...
+            </>
+          ) : (
+            <>
+              <IoSparkles size={16} />
+              ChatGPTに分析してもらう
+            </>
+          )}
+        </button>
+
+        {!canRequestAiInsight && !aiLoading && (
+          <p className="mt-2 flex items-start gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+            <IoWarningOutline size={14} className="mt-0.5 flex-shrink-0" />
+            地図にデータをプロットすると分析を依頼できます。対応ファイルを選択し、表示を確認してください。
+          </p>
+        )}
+
+        {aiError && (
+          <div className="mt-2 rounded border border-red-200 bg-red-50 p-2 text-[11px] text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300">
+            {aiError}
+          </div>
+        )}
+
+        {aiResult && (
+          <div className="mt-4 space-y-3">
+            <div>
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">要点</h3>
+              <ul className="mt-1 list-disc space-y-1 pl-4 text-[11px] leading-relaxed text-gray-700 dark:text-gray-200">
+                {aiResult.bulletSummary.map((item, index) => (
+                  <li key={`gis-sidebar-ai-bullet-${index}`}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Markdownレポート</h3>
+              <div className="mt-2 max-h-48 overflow-y-auto rounded border border-gray-200 bg-white p-3 text-[11px] leading-relaxed text-gray-800 shadow-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{aiResult.markdown}</ReactMarkdown>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -12,7 +12,6 @@ import {
   IoDownloadOutline,
   IoKeyOutline,
   IoHelpCircleOutline,
-  IoGlobeOutline,
 } from 'react-icons/io5';
 
 interface MainHeaderProps {
@@ -33,9 +32,6 @@ interface MainHeaderProps {
   onToggleHelp: () => void;
   isHelpPaneVisible: boolean;
   onOpenLlmSettings: () => void;
-  isGisData: boolean;
-  isGisModeActive: boolean;
-  onToggleGisMode: () => void;
 }
 
 const MainHeader: React.FC<MainHeaderProps> = ({
@@ -56,18 +52,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleHelp,
   isHelpPaneVisible,
   onOpenLlmSettings,
-  isGisData,
-  isGisModeActive,
-  onToggleGisMode,
 }) => {
   const isDark = theme === 'dark';
-
-  const canToggleGisMode = isGisData || isGisModeActive;
-  const gisButtonLabel = isGisModeActive
-    ? 'GIS分析モードを終了'
-    : isGisData
-      ? 'GIS分析モードを表示'
-      : 'GIS対応ファイルを開くと利用できます';
 
   return (
     <header className="flex items-center px-4 h-12 bg-white border-b border-gray-300 dark:bg-gray-900 dark:border-gray-700">
@@ -135,72 +121,6 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         title="OpenAI APIキー設定"
       >
         <IoKeyOutline size={20} />
-      </button>
-      {isGisData && (
-        <button
-          className={`p-1 rounded ml-2 ${
-            isGisModeActive ? 'bg-teal-100 text-teal-700' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-          }`}
-          onClick={onToggleGisMode}
-          aria-label="Toggle GIS Analysis Mode"
-          title={`GIS分析モードを${isGisModeActive ? '終了' : '表示'}`}
-        >
-          <IoGlobeOutline size={20} />
-        </button>
-      )}
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
-      </button>
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
-      </button>
-      <button
-        className={`p-1 rounded ml-2 ${
-          isGisModeActive
-            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-200'
-            : 'hover:bg-gray-200 dark:hover:bg-gray-800'
-        } ${canToggleGisMode ? '' : 'opacity-40 cursor-not-allowed'}`}
-        onClick={() => {
-          if (!canToggleGisMode) {
-            return;
-          }
-          onToggleGisMode();
-        }}
-        aria-label="Toggle GIS Analysis Mode"
-        title={gisButtonLabel}
-        type="button"
-      >
-        <IoGlobeOutline size={20} />
       </button>
       <button
         className={`p-1 rounded ml-2 ${

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -233,13 +233,6 @@ const MainLayout = () => {
     setViewMode(activeTabId, nextMode);
   }, [activeTabId, activeTabViewMode, fileTypeFlags.isGisData, setViewMode]);
 
-  const handleToggleGisAnalysisMode = useCallback(() => {
-    if (!activeTabId || !fileTypeFlags.isGisData) return;
-
-    const nextMode = activeTabViewMode === 'gis-analysis' ? 'editor' : 'gis-analysis';
-    setViewMode(activeTabId, nextMode);
-  }, [activeTabId, activeTabViewMode, fileTypeFlags.isGisData, setViewMode]);
-
   const handleConfirmNewFile = useCallback(
     async (fileName: string) => {
       setShowNewFileDialog(false);
@@ -491,9 +484,6 @@ const MainLayout = () => {
         onToggleHelp={handleToggleHelpPane}
         isHelpPaneVisible={paneState.isHelpVisible}
         onOpenLlmSettings={() => setShowLlmSettingsDialog(true)}
-        isGisData={fileTypeFlags.isGisData}
-        isGisModeActive={activeTabViewMode === 'gis-analysis'}
-        onToggleGisMode={handleToggleGisAnalysisMode}
       />
 
       <TabBarDnD />

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -39,49 +39,10 @@ const Workspace: React.FC<WorkspaceProps> = ({
   onCloseMultiFileAnalysis,
 }) => {
   const updatePaneState = useEditorStore((state) => state.updatePaneState);
+  const setViewMode = useEditorStore((state) => state.setViewMode);
   const editorRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const [isScrollSyncEnabled, setIsScrollSyncEnabled] = useState(false);
-
-  const activeSidebar = useMemo(() => {
-    if (paneState.activeSidebar !== undefined && paneState.activeSidebar !== null) {
-      return paneState.activeSidebar;
-    }
-    if (paneState.isExplorerVisible) {
-      return 'explorer';
-    }
-    if (paneState.isGitVisible) {
-      return 'git';
-    }
-    if (paneState.isGisVisible) {
-      return 'gis';
-    }
-    if (paneState.isHelpVisible) {
-      return 'help';
-    }
-    return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
-
-  const showExplorer = activeSidebar === 'explorer';
-  const showGitSidebar = activeSidebar === 'git';
-  const showGisSidebar = activeSidebar === 'gis';
-  const showHelpSidebar = activeSidebar === 'help';
-
-  const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
-      const isActive = activeSidebar === sidebar;
-      updatePaneState({
-        activeSidebar: isActive ? null : sidebar,
-        isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
-        isGisVisible: sidebar === 'gis' ? !isActive : false,
-        isGitVisible: sidebar === 'git' ? !isActive : false,
-        isHelpVisible: sidebar === 'help' ? !isActive : false,
-      });
-    },
-  [activeSidebar, updatePaneState]
-  );
-
-  const showSearchPanel = paneState.isSearchVisible;
 
   const {
     isMarkdown,
@@ -123,6 +84,56 @@ const Workspace: React.FC<WorkspaceProps> = ({
       isGisData: gisData,
     };
   }, [activeTab]);
+
+  const activeSidebar = useMemo(() => {
+    if (paneState.activeSidebar !== undefined && paneState.activeSidebar !== null) {
+      return paneState.activeSidebar;
+    }
+    if (paneState.isExplorerVisible) {
+      return 'explorer';
+    }
+    if (paneState.isGitVisible) {
+      return 'git';
+    }
+    if (paneState.isGisVisible) {
+      return 'gis';
+    }
+    if (paneState.isHelpVisible) {
+      return 'help';
+    }
+    return null;
+  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
+
+  const showExplorer = activeSidebar === 'explorer';
+  const showGitSidebar = activeSidebar === 'git';
+  const showGisSidebar = activeSidebar === 'gis';
+  const showHelpSidebar = activeSidebar === 'help';
+
+  const handleSidebarSelect = useCallback(
+    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
+      const isActive = activeSidebar === sidebar;
+      updatePaneState({
+        activeSidebar: isActive ? null : sidebar,
+        isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
+        isGisVisible: sidebar === 'gis' ? !isActive : false,
+        isGitVisible: sidebar === 'git' ? !isActive : false,
+        isHelpVisible: sidebar === 'help' ? !isActive : false,
+      });
+
+      if (sidebar === 'gis' && activeTabId && isGisData) {
+        if (isActive) {
+          if (activeTabViewMode === 'gis-analysis') {
+            setViewMode(activeTabId, 'editor');
+          }
+        } else {
+          setViewMode(activeTabId, 'gis-analysis');
+        }
+      }
+    },
+    [activeSidebar, activeTabId, activeTabViewMode, isGisData, setViewMode, updatePaneState]
+  );
+
+  const showSearchPanel = paneState.isSearchVisible;
 
   const handleEditorScroll = useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {

--- a/src/store/gisStore.ts
+++ b/src/store/gisStore.ts
@@ -2,39 +2,89 @@
 
 import { create } from 'zustand';
 
+import type { AnalysisSummary } from '@/lib/llm/analysisSummarizer';
+
 interface GisAnalysisState {
-  selectedFilePath: string | null;
-  selectedColumn: string | null;
+  selectedFilePaths: string[];
+  activeFilePath: string | null;
+  selectedColumns: Record<string, string | null>;
   columnCache: Record<string, string[]>;
-  setSelectedFilePath: (path: string | null) => void;
-  setSelectedColumn: (column: string | null) => void;
+  analysisSummary: AnalysisSummary | null;
+  toggleSelectedFilePath: (path: string) => void;
+  setActiveFilePath: (path: string | null) => void;
+  setSelectedColumn: (path: string, column: string | null) => void;
   setColumnCache: (path: string, columns: string[]) => void;
   clearColumnCache: (path: string) => void;
+  setAnalysisSummary: (summary: AnalysisSummary | null) => void;
   reset: () => void;
 }
 
-const initialState: Pick<GisAnalysisState, 'selectedFilePath' | 'selectedColumn' | 'columnCache'> = {
-  selectedFilePath: null,
-  selectedColumn: null,
+const initialState: Pick<
+  GisAnalysisState,
+  'selectedFilePaths' | 'activeFilePath' | 'selectedColumns' | 'columnCache' | 'analysisSummary'
+> = {
+  selectedFilePaths: [],
+  activeFilePath: null,
+  selectedColumns: {},
   columnCache: {},
+  analysisSummary: null,
 };
 
 export const useGisAnalysisStore = create<GisAnalysisState>((set) => ({
   ...initialState,
-  setSelectedFilePath: (path) =>
-    set(() => ({
-      selectedFilePath: path,
-      // 選択ファイルが変わったらカラム選択をリセットする
-      selectedColumn: null,
-    })),
-  setSelectedColumn: (column) => set({ selectedColumn: column }),
+  toggleSelectedFilePath: (path) =>
+    set((state) => {
+      const exists = state.selectedFilePaths.includes(path);
+      let selectedFilePaths = state.selectedFilePaths;
+      let activeFilePath = state.activeFilePath;
+      const selectedColumns = { ...state.selectedColumns };
+
+      if (exists) {
+        selectedFilePaths = state.selectedFilePaths.filter((item) => item !== path);
+        delete selectedColumns[path];
+        if (activeFilePath === path) {
+          activeFilePath = selectedFilePaths[0] ?? null;
+        }
+      } else {
+        selectedFilePaths = [...state.selectedFilePaths, path];
+        if (!activeFilePath) {
+          activeFilePath = path;
+        }
+      }
+
+      return {
+        selectedFilePaths,
+        activeFilePath,
+        selectedColumns,
+      };
+    }),
+  setActiveFilePath: (path) =>
+    set((state) => {
+      if (path === null) {
+        return { activeFilePath: null };
+      }
+
+      const selectedFilePaths = state.selectedFilePaths.includes(path)
+        ? state.selectedFilePaths
+        : [...state.selectedFilePaths, path];
+
+      return {
+        selectedFilePaths,
+        activeFilePath: path,
+      };
+    }),
+  setSelectedColumn: (path, column) =>
+    set((state) => ({ selectedColumns: { ...state.selectedColumns, [path]: column } })),
   setColumnCache: (path, columns) =>
     set((state) => ({ columnCache: { ...state.columnCache, [path]: columns } })),
   clearColumnCache: (path) =>
     set((state) => {
-      const next = { ...state.columnCache };
-      delete next[path];
-      return { columnCache: next };
+      const nextCache = { ...state.columnCache };
+      delete nextCache[path];
+      const nextColumns = { ...state.selectedColumns };
+      delete nextColumns[path];
+      return { columnCache: nextCache, selectedColumns: nextColumns };
     }),
+  setAnalysisSummary: (summary) => set({ analysisSummary: summary }),
   reset: () => set({ ...initialState }),
 }));


### PR DESCRIPTION
## Summary
- allow multiple GIS files to be selected simultaneously from the sidebar and track their independent column choices
- render all selected GIS datasets together on the map with per-layer styling and collapsible attribute tables
- preserve ChatGPT integration while refreshing AI context from the active dataset metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde563eb98832f95cd5d04dba51ed4