### PR TITLE
Enable switching to analysis mode via mode toggle

### DIFF
--- a/src/components/analysis/DataAnalysis.tsx
+++ b/src/components/analysis/DataAnalysis.tsx
@@ -93,9 +93,22 @@ const DataAnalysis: React.FC<DataAnalysisProps> = ({ tabId }) => {
   };
 
   const toggleAnalysisMode = () => {
-    updatePaneState({ 
-      isAnalysisVisible: !paneState.isAnalysisVisible 
-    });
+    const tab = tabs.get(tabId);
+    const type = tab?.type?.toLowerCase();
+    const isDataPreviewable =
+      type === 'csv' ||
+      type === 'tsv' ||
+      type === 'json' ||
+      type === 'yaml' ||
+      type === 'parquet' ||
+      type === 'excel' ||
+      type === 'geojson' ||
+      type === 'kml' ||
+      type === 'kmz' ||
+      type === 'shapefile';
+
+    const fallbackMode = isDataPreviewable ? 'data-preview' : 'editor';
+    setViewMode(tabId, fallbackMode);
   };
   
   const toggleDisplayMode = () => {

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -320,7 +320,7 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
       currentType === 'shapefile';
 
     // エディタ → プレビュー → データプレビュー → GIS分析 → 分割表示 → エディタ の順に切り替え
-    let newMode: 'editor' | 'preview' | 'data-preview' | 'split' | 'gis-analysis';
+    let newMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
     if (isGisFile) {
       if (viewMode === 'editor') {
         newMode = 'preview';
@@ -329,7 +329,11 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
       } else if (viewMode === 'data-preview') {
         newMode = 'gis-analysis';
       } else if (viewMode === 'gis-analysis') {
+        newMode = 'analysis';
+      } else if (viewMode === 'analysis') {
         newMode = 'split';
+      } else if (viewMode === 'split') {
+        newMode = 'editor';
       } else {
         newMode = 'editor';
       }
@@ -339,7 +343,11 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
       } else if (viewMode === 'preview') {
         newMode = 'data-preview';
       } else if (viewMode === 'data-preview') {
+        newMode = 'analysis';
+      } else if (viewMode === 'analysis') {
         newMode = 'split';
+      } else if (viewMode === 'split') {
+        newMode = 'editor';
       } else {
         newMode = 'editor';
       }
@@ -363,7 +371,9 @@ const Editor = forwardRef<HTMLDivElement, EditorProps>(({ tabId, onScroll }, ref
   };
   
   const toggleAnalysisMode = () => {
-    updatePaneState({ isAnalysisVisible: !paneState.isAnalysisVisible });
+    const isCurrentlyAnalysis = viewMode === 'analysis';
+    const nextMode = isCurrentlyAnalysis ? 'editor' : 'analysis';
+    setViewMode(tabId, nextMode);
   };
 
   // ファイルの保存処理

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -217,21 +217,29 @@ const MainLayout = () => {
         if (activeTabViewMode === 'editor') return 'preview';
         if (activeTabViewMode === 'preview') return 'data-preview';
         if (activeTabViewMode === 'data-preview') return 'gis-analysis';
-        if (activeTabViewMode === 'gis-analysis') return 'split';
+        if (activeTabViewMode === 'gis-analysis') return 'analysis';
+        if (activeTabViewMode === 'analysis') return 'split';
+        if (activeTabViewMode === 'split') return 'editor';
         return 'editor';
       }
 
-      return activeTabViewMode === 'editor'
-        ? 'preview'
-        : activeTabViewMode === 'preview'
-          ? 'data-preview'
-          : activeTabViewMode === 'data-preview'
-            ? 'split'
-            : 'editor';
+      if (fileTypeFlags.isDataPreviewable) {
+        if (activeTabViewMode === 'editor') return 'preview';
+        if (activeTabViewMode === 'preview') return 'data-preview';
+        if (activeTabViewMode === 'data-preview') return 'analysis';
+        if (activeTabViewMode === 'analysis') return 'split';
+        if (activeTabViewMode === 'split') return 'editor';
+        return 'editor';
+      }
+
+      if (activeTabViewMode === 'editor') return 'preview';
+      if (activeTabViewMode === 'preview') return 'split';
+      if (activeTabViewMode === 'split') return 'editor';
+      return 'editor';
     })();
 
     setViewMode(activeTabId, nextMode);
-  }, [activeTabId, activeTabViewMode, fileTypeFlags.isGisData, setViewMode]);
+  }, [activeTabId, activeTabViewMode, fileTypeFlags.isDataPreviewable, fileTypeFlags.isGisData, setViewMode]);
 
   const handleConfirmNewFile = useCallback(
     async (fileName: string) => {

--- a/src/components/layout/ViewModeBanner.tsx
+++ b/src/components/layout/ViewModeBanner.tsx
@@ -5,7 +5,7 @@ import { TabData } from '@/types';
 
 interface ViewModeBannerProps {
   activeTab: TabData | null;
-  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'split' | 'gis-analysis';
+  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
   canToggleViewMode: boolean;
   onToggleViewMode: () => void;
 }
@@ -27,9 +27,11 @@ const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
         ? 'プレビュー'
         : activeTabViewMode === 'data-preview'
           ? 'GUIデザインモード'
-          : activeTabViewMode === 'gis-analysis'
-            ? 'GIS分析'
-            : '分割表示';
+          : activeTabViewMode === 'analysis'
+            ? '分析モード'
+            : activeTabViewMode === 'gis-analysis'
+              ? 'GIS分析'
+              : '分割表示';
 
   const modeClassName =
     activeTabViewMode === 'editor'
@@ -38,9 +40,11 @@ const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
         ? 'bg-green-100 text-green-800'
         : activeTabViewMode === 'data-preview'
           ? 'bg-indigo-100 text-indigo-800'
-          : activeTabViewMode === 'gis-analysis'
-            ? 'bg-teal-100 text-teal-800'
-            : 'bg-purple-100 text-purple-800';
+          : activeTabViewMode === 'analysis'
+            ? 'bg-amber-100 text-amber-800'
+            : activeTabViewMode === 'gis-analysis'
+              ? 'bg-teal-100 text-teal-800'
+              : 'bg-purple-100 text-purple-800';
 
   return (
     <div className="bg-gray-100 dark:bg-gray-900 px-2 py-1 border-b border-gray-300 dark:border-gray-700 flex justify-between items-center">

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -25,7 +25,7 @@ interface WorkspaceProps {
   paneState: PaneState;
   activeTab: TabData | null;
   activeTabId: string | null;
-  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'split' | 'gis-analysis';
+  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
   multiFileAnalysisEnabled: boolean;
   onCloseMultiFileAnalysis: () => void;
 }
@@ -342,7 +342,9 @@ const Workspace: React.FC<WorkspaceProps> = ({
       return <GitCommitDiffView tab={activeTab} />;
     }
 
-    if (isDataAnalyzable && paneState.isAnalysisVisible) {
+    const shouldShowAnalysis = isDataAnalyzable && (paneState.isAnalysisVisible || activeTabViewMode === 'analysis');
+
+    if (shouldShowAnalysis) {
       return (
         <div className="w-full h-full overflow-hidden">
           <DataAnalysis tabId={activeTabId} />

--- a/src/components/preview/DataPreview.tsx
+++ b/src/components/preview/DataPreview.tsx
@@ -658,7 +658,8 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
   };
   
   const toggleAnalysisMode = () => {
-    updatePaneState({ isAnalysisVisible: !paneState.isAnalysisVisible });
+    const nextMode = viewMode === 'analysis' ? 'editor' : 'analysis';
+    setViewMode(tabId, nextMode);
   };
   
   const toggleDisplayMode = () => {
@@ -976,7 +977,7 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
             {(type === 'csv' || type === 'tsv' || type === 'json' || type === 'yaml' || type === 'parquet' || type === 'excel') && (
               <button
                 className={`px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 mr-2 flex items-center ${paneState.isAnalysisVisible ? 'bg-blue-100 dark:bg-blue-900' : ''}`}
-                onClick={() => updatePaneState({ isAnalysisVisible: !paneState.isAnalysisVisible })}
+                onClick={toggleAnalysisMode}
                 title={paneState.isAnalysisVisible ? '分析モードを閉じる' : '分析モードに切り替え'}
               >
                 <IoAnalytics size={20} className="mr-1" /> 分析

--- a/src/components/preview/DataPreviewFixed.tsx
+++ b/src/components/preview/DataPreviewFixed.tsx
@@ -369,7 +369,8 @@ const DataPreview: React.FC<DataPreviewProps> = ({ tabId }) => {
   };
   
   const toggleAnalysisMode = () => {
-    updatePaneState({ isAnalysisVisible: !paneState.isAnalysisVisible });
+    const nextMode = viewMode === 'analysis' ? 'editor' : 'analysis';
+    setViewMode(tabId, nextMode);
   };
   
   const toggleDisplayMode = () => {

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -24,7 +24,7 @@ import {
   HelpUserRole,
 } from '@/types';
 
-type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'split' | 'gis-analysis';
+type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
 
 interface EditorStore {
   // タブ管理
@@ -219,8 +219,17 @@ export const useEditorStore = create<EditorStore>()(
       setViewMode: (tabId, mode) => set((state) => {
         const newViewModes = new Map(state.viewModes);
         newViewModes.set(tabId, mode);
-        // グローバル lastViewMode を更新
-        return { viewModes: newViewModes, lastViewMode: mode };
+
+        const isAnalysisMode = mode === 'analysis';
+        const shouldUpdatePaneState = state.paneState.isAnalysisVisible !== isAnalysisMode;
+
+        return {
+          viewModes: newViewModes,
+          lastViewMode: mode === 'analysis' ? state.lastViewMode : mode,
+          paneState: shouldUpdatePaneState
+            ? { ...state.paneState, isAnalysisVisible: isAnalysisMode }
+            : state.paneState,
+        };
       }),
       getViewMode: (tabId) => {
         const mode = get().viewModes.get(tabId);


### PR DESCRIPTION
## Summary
- extend the editor view mode state to include an `analysis` option and keep the analysis pane visibility in sync
- update mode toggle logic and labels so the "モード切替" cycle now reaches the analysis view for data files
- adjust analysis controls to switch back to the appropriate non-analysis view when closing the mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de351a6624832fab562ad1c1626734