### PR TITLE
feat: add dropdown for view mode switching

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useEditorStore } from '@/store/editorStore';
+import { useEditorStore, type EditorViewMode } from '@/store/editorStore';
 import { useGitStore } from '@/store/gitStore';
 import TabBarDnD from '@/components/tabs/TabBarDnD';
 import InputDialog from '@/components/modals/InputDialog';
@@ -63,7 +63,7 @@ const MainLayoutContent: React.FC = () => {
   const gitLoading = useGitStore((state) => state.loading);
 
   const activeTab = activeTabId ? tabs.get(activeTabId) : null;
-  const activeTabViewMode = activeTabId ? getViewMode(activeTabId) : 'editor';
+  const activeTabViewMode: EditorViewMode = activeTabId ? getViewMode(activeTabId) : 'editor';
 
   const fileTypeFlags = useMemo(() => {
     const type = activeTab?.type?.toLowerCase();
@@ -217,37 +217,13 @@ const MainLayoutContent: React.FC = () => {
     useGitStore.setState({ error: null });
   }, []);
 
-  const handleCycleViewMode = useCallback(() => {
-    if (!activeTabId) return;
-
-    const nextMode = (() => {
-      if (fileTypeFlags.isGisData) {
-        if (activeTabViewMode === 'editor') return 'preview';
-        if (activeTabViewMode === 'preview') return 'data-preview';
-        if (activeTabViewMode === 'data-preview') return 'gis-analysis';
-        if (activeTabViewMode === 'gis-analysis') return 'analysis';
-        if (activeTabViewMode === 'analysis') return 'split';
-        if (activeTabViewMode === 'split') return 'editor';
-        return 'editor';
-      }
-
-      if (fileTypeFlags.isDataPreviewable) {
-        if (activeTabViewMode === 'editor') return 'preview';
-        if (activeTabViewMode === 'preview') return 'data-preview';
-        if (activeTabViewMode === 'data-preview') return 'analysis';
-        if (activeTabViewMode === 'analysis') return 'split';
-        if (activeTabViewMode === 'split') return 'editor';
-        return 'editor';
-      }
-
-      if (activeTabViewMode === 'editor') return 'preview';
-      if (activeTabViewMode === 'preview') return 'split';
-      if (activeTabViewMode === 'split') return 'editor';
-      return 'editor';
-    })();
-
-    setViewMode(activeTabId, nextMode);
-  }, [activeTabId, activeTabViewMode, fileTypeFlags.isDataPreviewable, fileTypeFlags.isGisData, setViewMode]);
+  const handleChangeViewMode = useCallback(
+    (mode: EditorViewMode) => {
+      if (!activeTabId) return;
+      setViewMode(activeTabId, mode);
+    },
+    [activeTabId, setViewMode],
+  );
 
   const handleConfirmNewFile = useCallback(
     async (fileName: string) => {
@@ -351,8 +327,42 @@ const MainLayoutContent: React.FC = () => {
   }, [gitLoading, isCloningRepo]);
 
   const canToggleViewMode = useMemo(() => {
-    return Boolean(activeTab && (fileTypeFlags.isPreviewableSpecialType || fileTypeFlags.isDataPreviewable));
-  }, [activeTab, fileTypeFlags.isDataPreviewable, fileTypeFlags.isPreviewableSpecialType]);
+    return Boolean(activeTab && (fileTypeFlags.isPreviewableSpecialType || fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData));
+  }, [activeTab, fileTypeFlags.isDataPreviewable, fileTypeFlags.isGisData, fileTypeFlags.isPreviewableSpecialType]);
+
+  const availableViewModes = useMemo<EditorViewMode[]>(() => {
+    if (!activeTab) {
+      return [activeTabViewMode];
+    }
+
+    const modes: EditorViewMode[] = ['editor'];
+
+    if (fileTypeFlags.isPreviewableSpecialType || fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData) {
+      modes.push('preview');
+    }
+
+    if (fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData) {
+      modes.push('data-preview');
+    }
+
+    if (fileTypeFlags.isGisData) {
+      modes.push('gis-analysis');
+    }
+
+    if (fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData) {
+      modes.push('analysis');
+    }
+
+    if (fileTypeFlags.isPreviewableSpecialType || fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData) {
+      modes.push('split');
+    }
+
+    if (!modes.includes(activeTabViewMode)) {
+      modes.push(activeTabViewMode);
+    }
+
+    return Array.from(new Set(modes));
+  }, [activeTab, activeTabViewMode, fileTypeFlags]);
 
   const handleDroppedFiles = useCallback(
     async (inputFiles: FileList | File[]) => {
@@ -533,7 +543,8 @@ const MainLayoutContent: React.FC = () => {
         activeTab={activeTab ?? null}
         activeTabViewMode={activeTabViewMode}
         canToggleViewMode={canToggleViewMode}
-        onToggleViewMode={handleCycleViewMode}
+        availableViewModes={availableViewModes}
+        onSelectViewMode={handleChangeViewMode}
       />
 
       <Workspace

--- a/src/components/layout/ViewModeBanner.tsx
+++ b/src/components/layout/ViewModeBanner.tsx
@@ -2,49 +2,48 @@
 
 import React from 'react';
 import { TabData } from '@/types';
+import { type EditorViewMode } from '@/store/editorStore';
+
+const MODE_LABELS: Record<EditorViewMode, string> = {
+  editor: 'エディタ',
+  preview: 'プレビュー',
+  'data-preview': 'GUIデザインモード',
+  analysis: '分析モード',
+  split: '分割表示',
+  'gis-analysis': 'GIS分析',
+};
+
+const MODE_CLASS_NAMES: Record<EditorViewMode, string> = {
+  editor: 'bg-blue-100 text-blue-800',
+  preview: 'bg-green-100 text-green-800',
+  'data-preview': 'bg-indigo-100 text-indigo-800',
+  analysis: 'bg-amber-100 text-amber-800',
+  split: 'bg-purple-100 text-purple-800',
+  'gis-analysis': 'bg-teal-100 text-teal-800',
+};
 
 interface ViewModeBannerProps {
   activeTab: TabData | null;
-  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
+  activeTabViewMode: EditorViewMode;
   canToggleViewMode: boolean;
-  onToggleViewMode: () => void;
+  availableViewModes: EditorViewMode[];
+  onSelectViewMode: (mode: EditorViewMode) => void;
 }
 
 const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
   activeTab,
   activeTabViewMode,
   canToggleViewMode,
-  onToggleViewMode,
+  availableViewModes,
+  onSelectViewMode,
 }) => {
   if (!activeTab) {
     return null;
   }
 
-  const modeLabel =
-    activeTabViewMode === 'editor'
-      ? 'エディタ'
-      : activeTabViewMode === 'preview'
-        ? 'プレビュー'
-        : activeTabViewMode === 'data-preview'
-          ? 'GUIデザインモード'
-          : activeTabViewMode === 'analysis'
-            ? '分析モード'
-            : activeTabViewMode === 'gis-analysis'
-              ? 'GIS分析'
-              : '分割表示';
-
-  const modeClassName =
-    activeTabViewMode === 'editor'
-      ? 'bg-blue-100 text-blue-800'
-      : activeTabViewMode === 'preview'
-        ? 'bg-green-100 text-green-800'
-        : activeTabViewMode === 'data-preview'
-          ? 'bg-indigo-100 text-indigo-800'
-          : activeTabViewMode === 'analysis'
-            ? 'bg-amber-100 text-amber-800'
-            : activeTabViewMode === 'gis-analysis'
-              ? 'bg-teal-100 text-teal-800'
-              : 'bg-purple-100 text-purple-800';
+  const modeLabel = MODE_LABELS[activeTabViewMode];
+  const modeClassName = MODE_CLASS_NAMES[activeTabViewMode];
+  const showModeSelector = canToggleViewMode && availableViewModes.length > 1;
 
   return (
     <div className="bg-gray-100 dark:bg-gray-900 px-2 py-1 border-b border-gray-300 dark:border-gray-700 flex justify-between items-center">
@@ -54,13 +53,21 @@ const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
           {modeLabel}
         </span>
       </div>
-      {canToggleViewMode && (
-        <button
-          className="px-2 py-1 text-xs bg-gray-200 rounded hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700"
-          onClick={onToggleViewMode}
-        >
-          モード切替
-        </button>
+      {showModeSelector && (
+        <div className="flex items-center text-xs">
+          <span className="mr-2">モード切替:</span>
+          <select
+            className="px-2 py-1 border border-gray-300 rounded bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-600"
+            value={activeTabViewMode}
+            onChange={(event) => onSelectViewMode(event.target.value as EditorViewMode)}
+          >
+            {availableViewModes.map((mode) => (
+              <option key={mode} value={mode}>
+                {MODE_LABELS[mode]}
+              </option>
+            ))}
+          </select>
+        </div>
       )}
     </div>
   );

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -24,7 +24,7 @@ import {
   HelpUserRole,
 } from '@/types';
 
-type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
+export type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
 
 interface EditorStore {
   // タブ管理


### PR DESCRIPTION
## Summary
- replace the view mode toggle button with a dropdown menu that lists only modes supported by the active tab
- compute the available modes per file type in the main layout and share the EditorViewMode type across components
- update the banner styling to include a labeled selector while keeping the current mode badge

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de9c9c2900832fa461480560114afc