### PR TITLE
fix: restore analysis mode and multi-file access

### DIFF
--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import React from 'react';
-import { IoFolderOpenOutline, IoGlobeOutline, IoGitBranchOutline, IoChatbubblesOutline } from 'react-icons/io5';
+import {
+  IoFolderOpenOutline,
+  IoGlobeOutline,
+  IoGitBranchOutline,
+  IoChatbubblesOutline,
+  IoGitMergeOutline,
+} from 'react-icons/io5';
 
 type ActivityItem = 'explorer' | 'gis' | 'git' | 'help';
 
@@ -9,9 +15,19 @@ interface ActivityBarProps {
   activeItem: ActivityItem | null;
   onSelect: (item: ActivityItem) => void;
   helpEnabled: boolean;
+  multiFileAnalysisAvailable: boolean;
+  multiFileAnalysisEnabled: boolean;
+  onToggleMultiFileAnalysis: () => void;
 }
 
-const ActivityBar: React.FC<ActivityBarProps> = ({ activeItem, onSelect, helpEnabled }) => {
+const ActivityBar: React.FC<ActivityBarProps> = ({
+  activeItem,
+  onSelect,
+  helpEnabled,
+  multiFileAnalysisAvailable,
+  multiFileAnalysisEnabled,
+  onToggleMultiFileAnalysis,
+}) => {
   const baseButton =
     'w-10 h-10 flex items-center justify-center rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500';
   const inactiveClass = 'text-gray-600 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-800';
@@ -28,6 +44,17 @@ const ActivityBar: React.FC<ActivityBarProps> = ({ activeItem, onSelect, helpEna
       >
         <IoFolderOpenOutline size={20} />
       </button>
+      {multiFileAnalysisAvailable && (
+        <button
+          type="button"
+          className={`${baseButton} mt-2 ${multiFileAnalysisEnabled ? activeClass : inactiveClass}`}
+          onClick={onToggleMultiFileAnalysis}
+          title={`複数ファイル分析モード ${multiFileAnalysisEnabled ? 'ON' : 'OFF'}`}
+          aria-pressed={multiFileAnalysisEnabled}
+        >
+          <IoGitMergeOutline size={20} />
+        </button>
+      )}
       <button
         type="button"
         className={`${baseButton} mt-2 ${activeItem === 'gis' ? activeClass : inactiveClass}`}

--- a/src/components/layout/ViewModeBanner.tsx
+++ b/src/components/layout/ViewModeBanner.tsx
@@ -2,49 +2,48 @@
 
 import React from 'react';
 import { TabData } from '@/types';
+import { type EditorViewMode } from '@/store/editorStore';
+
+const MODE_LABELS: Record<EditorViewMode, string> = {
+  editor: 'エディタ',
+  preview: 'プレビュー',
+  'data-preview': 'GUIデザインモード',
+  analysis: '分析モード',
+  split: '分割表示',
+  'gis-analysis': 'GIS分析',
+};
+
+const MODE_CLASS_NAMES: Record<EditorViewMode, string> = {
+  editor: 'bg-blue-100 text-blue-800',
+  preview: 'bg-green-100 text-green-800',
+  'data-preview': 'bg-indigo-100 text-indigo-800',
+  analysis: 'bg-amber-100 text-amber-800',
+  split: 'bg-purple-100 text-purple-800',
+  'gis-analysis': 'bg-teal-100 text-teal-800',
+};
 
 interface ViewModeBannerProps {
   activeTab: TabData | null;
-  activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
+  activeTabViewMode: EditorViewMode;
   canToggleViewMode: boolean;
-  onToggleViewMode: () => void;
+  availableViewModes: EditorViewMode[];
+  onSelectViewMode: (mode: EditorViewMode) => void;
 }
 
 const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
   activeTab,
   activeTabViewMode,
   canToggleViewMode,
-  onToggleViewMode,
+  availableViewModes,
+  onSelectViewMode,
 }) => {
   if (!activeTab) {
     return null;
   }
 
-  const modeLabel =
-    activeTabViewMode === 'editor'
-      ? 'エディタ'
-      : activeTabViewMode === 'preview'
-        ? 'プレビュー'
-        : activeTabViewMode === 'data-preview'
-          ? 'GUIデザインモード'
-          : activeTabViewMode === 'analysis'
-            ? '分析モード'
-            : activeTabViewMode === 'gis-analysis'
-              ? 'GIS分析'
-              : '分割表示';
-
-  const modeClassName =
-    activeTabViewMode === 'editor'
-      ? 'bg-blue-100 text-blue-800'
-      : activeTabViewMode === 'preview'
-        ? 'bg-green-100 text-green-800'
-        : activeTabViewMode === 'data-preview'
-          ? 'bg-indigo-100 text-indigo-800'
-          : activeTabViewMode === 'analysis'
-            ? 'bg-amber-100 text-amber-800'
-            : activeTabViewMode === 'gis-analysis'
-              ? 'bg-teal-100 text-teal-800'
-              : 'bg-purple-100 text-purple-800';
+  const modeLabel = MODE_LABELS[activeTabViewMode];
+  const modeClassName = MODE_CLASS_NAMES[activeTabViewMode];
+  const showModeSelector = canToggleViewMode && availableViewModes.length > 1;
 
   return (
     <div className="bg-gray-100 dark:bg-gray-900 px-2 py-1 border-b border-gray-300 dark:border-gray-700 flex justify-between items-center">
@@ -54,13 +53,21 @@ const ViewModeBanner: React.FC<ViewModeBannerProps> = ({
           {modeLabel}
         </span>
       </div>
-      {canToggleViewMode && (
-        <button
-          className="px-2 py-1 text-xs bg-gray-200 rounded hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700"
-          onClick={onToggleViewMode}
-        >
-          モード切替
-        </button>
+      {showModeSelector && (
+        <div className="flex items-center text-xs">
+          <span className="mr-2">モード切替:</span>
+          <select
+            className="px-2 py-1 border border-gray-300 rounded bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-600"
+            value={activeTabViewMode}
+            onChange={(event) => onSelectViewMode(event.target.value as EditorViewMode)}
+          >
+            {availableViewModes.map((mode) => (
+              <option key={mode} value={mode}>
+                {MODE_LABELS[mode]}
+              </option>
+            ))}
+          </select>
+        </div>
       )}
     </div>
   );

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -28,6 +28,7 @@ interface WorkspaceProps {
   activeTabViewMode: 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
   multiFileAnalysisEnabled: boolean;
   onCloseMultiFileAnalysis: () => void;
+  onToggleMultiFileAnalysis: () => void;
   aiFeaturesEnabled: boolean;
 }
 
@@ -38,6 +39,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
   activeTabViewMode,
   multiFileAnalysisEnabled,
   onCloseMultiFileAnalysis,
+  onToggleMultiFileAnalysis,
   aiFeaturesEnabled,
 }) => {
   const updatePaneState = useEditorStore((state) => state.updatePaneState);
@@ -348,7 +350,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
     }
 
     const shouldShowAnalysis =
-      aiFeaturesEnabled && isDataAnalyzable && (paneState.isAnalysisVisible || activeTabViewMode === 'analysis');
+      isDataAnalyzable && (paneState.isAnalysisVisible || activeTabViewMode === 'analysis');
 
     if (shouldShowAnalysis) {
       return (
@@ -363,7 +365,14 @@ const Workspace: React.FC<WorkspaceProps> = ({
 
   return (
     <div className="flex flex-1 overflow-hidden bg-white dark:bg-gray-900">
-      <ActivityBar activeItem={activeSidebar} onSelect={handleSidebarSelect} helpEnabled={aiFeaturesEnabled} />
+      <ActivityBar
+        activeItem={activeSidebar}
+        onSelect={handleSidebarSelect}
+        helpEnabled={aiFeaturesEnabled}
+        multiFileAnalysisAvailable={aiFeaturesEnabled}
+        multiFileAnalysisEnabled={multiFileAnalysisEnabled}
+        onToggleMultiFileAnalysis={onToggleMultiFileAnalysis}
+      />
       {showExplorer && (
         <div className="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-800">
           <FileExplorer />

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -24,7 +24,7 @@ import {
   HelpUserRole,
 } from '@/types';
 
-type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
+export type EditorViewMode = 'editor' | 'preview' | 'data-preview' | 'analysis' | 'split' | 'gis-analysis';
 
 interface EditorStore {
   // タブ管理


### PR DESCRIPTION
## Summary
- ensure analysis mode shows the analysis panel for data files instead of falling back to split view
- add a multi-file analysis toggle button to the activity bar and plumb the layout handler

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de9c9c2900832fa461480560114afc