### PR TITLE
ドーナツチャート設定の追加

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,11 @@ export interface ChartDesignerSettings {
   ganttTaskField: string;
   ganttStartField: string;
   ganttEndField: string;
+  sunburstLevel1Field: string;
+  sunburstLevel2Field: string;
+  sunburstLevel3Field: string;
+  pieHole: number;
+  sunburstHole: number;
   collapsed: boolean;
 }
 


### PR DESCRIPTION
## Summary
- 円グラフに内側のくり抜き率を指定できるスライダーを追加し、Plotly出力の hole 値に反映しました
- サンバーストチャートでもドーナツ形状を選べるようにし、設定値を状態管理と描画ロジックに保存しました
- チャートデザイナー設定型にドーナツ設定用のフィールドを追加しました

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df168f9c74832fb37f4a45ac850f94