### PR TITLE
Enable GUI design mode toggle for git flow diagrams

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -70,7 +70,7 @@ const MainLayoutContent: React.FC = () => {
     const isMarkdown = type === 'markdown' || type === 'md';
     const isMermaid = type === 'mermaid' || type === 'mmd';
     const isHtml = type === 'html';
-    const isDataPreviewable =
+    const isStructuredDataPreviewable =
       type === 'csv' ||
       type === 'tsv' ||
       type === 'json' ||
@@ -81,6 +81,7 @@ const MainLayoutContent: React.FC = () => {
       type === 'kml' ||
       type === 'kmz' ||
       type === 'shapefile';
+    const isDataPreviewable = isStructuredDataPreviewable || isMermaid;
 
     return {
       isMarkdown,
@@ -346,7 +347,7 @@ const MainLayoutContent: React.FC = () => {
       modes.push('gis-analysis');
     }
 
-    if (fileTypeFlags.isDataPreviewable || fileTypeFlags.isGisData) {
+    if ((fileTypeFlags.isDataPreviewable && !fileTypeFlags.isMermaid) || fileTypeFlags.isGisData) {
       modes.push('analysis');
     }
 

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -61,7 +61,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
     const markdown = fileType === 'markdown' || fileType === 'md';
     const mermaid = fileType === 'mermaid' || fileType === 'mmd';
     const html = fileType === 'html';
-    const dataPreviewable =
+    const structuredDataPreviewable =
       fileType === 'csv' ||
       fileType === 'tsv' ||
       fileType === 'json' ||
@@ -72,6 +72,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
       fileType === 'kml' ||
       fileType === 'kmz' ||
       fileType === 'shapefile';
+    const dataPreviewable = structuredDataPreviewable || mermaid;
     const gisData =
       fileType === 'geojson' ||
       fileType === 'kml' ||
@@ -84,7 +85,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
       isHtml: html,
       isPreviewableSpecialType: markdown || mermaid || html,
       isDataPreviewable: dataPreviewable,
-      isDataAnalyzable: dataPreviewable,
+      isDataAnalyzable: structuredDataPreviewable,
       isGisData: gisData,
     };
   }, [activeTab]);

--- a/src/store/gitStore.ts
+++ b/src/store/gitStore.ts
@@ -1019,7 +1019,11 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
               commandLines.push(`  checkout ${branchAliasValue}`);
               activeAlias = branchAliasValue;
             }
-            commandLines.push(`  merge ${mergeAlias} id: "${id}" tag: "${tag}"`);
+            if (mergeAlias === branchAliasValue) {
+              commandLines.push(`  commit id: "${id}" tag: "${tag}"`);
+            } else {
+              commandLines.push(`  merge ${mergeAlias} id: "${id}" tag: "${tag}"`);
+            }
 
             if (parents.length > 2) {
               legendLines.push(


### PR DESCRIPTION
## Summary
- allow Mermaid tabs, including git flow diagrams, to expose the GUIデザインモード view switch
- prevent the git flow Mermaid generator from emitting self-merges that rendered with "Cannot merge branch 'main' into itself"

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df695c2800832f90198d88849248cd