### PR TITLE
feat: add advanced charts to analysis mode

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,7 +142,13 @@ export type ResultChartType =
   | 'gantt'
   | 'treemap'
   | 'streamgraph'
-  | 'venn';
+  | 'venn'
+  | 'kde'
+  | 'heatmap'
+  | 'sankey'
+  | 'word-cloud'
+  | 'radial-bar'
+  | 'waterfall';
 
 export type ResultAggregation = 'sum' | 'avg' | 'count' | 'min' | 'max';
 
@@ -204,7 +210,13 @@ export interface ChartSettings {
     | 'gantt'
     | 'treemap'
     | 'streamgraph'
-    | 'venn';
+    | 'venn'
+    | 'kde'
+    | 'heatmap'
+    | 'sankey'
+    | 'word-cloud'
+    | 'radial-bar'
+    | 'waterfall';
   xAxis: string;
   yAxis: string;
   aggregation: 'sum' | 'avg' | 'count' | 'min' | 'max' | 'none';


### PR DESCRIPTION
## Summary
- add kernel density estimation, heatmap, sankey, word cloud, radial bar, and waterfall charts to the analysis plot builder
- extend chart aggregation helpers and configuration logic to render the new Plotly visualizations
- expose the new chart options through the shared ResultChartType definitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11616a3b4832fb6b728fb812914f6