### PR TITLE
Fix gitGraph serialization header colon

### DIFF
--- a/src/lib/mermaid/serializer.ts
+++ b/src/lib/mermaid/serializer.ts
@@ -386,7 +386,7 @@ const serializeGitGraph = (model: MermaidGraphModel): MermaidSerializationResult
   const config = model.config.type === 'gitGraph' ? model.config : diagramDefinitions.gitGraph.defaultConfig;
   const warnings: string[] = [];
   const orientation = config.orientation ?? 'LR';
-  const lines: string[] = [`gitGraph ${orientation}`];
+  const lines: string[] = [`gitGraph ${orientation}:`];
 
   const orderMap = new Map<string, number>();
   model.nodes.forEach((node, index) => {


### PR DESCRIPTION
## Summary
- ensure gitGraph mermaid serialization keeps the trailing colon required by the parser to prevent GUI rendering failures

## Testing
- npm run test -- gitGraphParser

------
https://chatgpt.com/codex/tasks/task_e_68e1391256dc832f80e17f3d62c52478