### PR TITLE
Normalize gitGraph headers for colonless inputs

### DIFF
--- a/src/lib/mermaid/__tests__/normalize.test.ts
+++ b/src/lib/mermaid/__tests__/normalize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMermaidSource } from '../normalize';
+
+describe('normalizeMermaidSource', () => {
+  it('keeps flowchart headers untouched except trimming orientation case', () => {
+    const source = 'flowchart td\n  A-->B';
+    expect(normalizeMermaidSource(source)).toBe('flowchart TD\n  A-->B');
+  });
+
+  it('ensures gitGraph headers include the trailing colon', () => {
+    const source = 'gitGraph LR\n  commit';
+    const normalized = normalizeMermaidSource(source);
+    expect(normalized.startsWith('gitGraph LR:')).toBe(true);
+  });
+
+  it('defaults gitGraph orientation to LR when missing', () => {
+    const source = '  gitGraph\n  commit';
+    const normalized = normalizeMermaidSource(source);
+    expect(normalized.startsWith('gitGraph LR:')).toBe(true);
+  });
+
+  it('preserves additional header content on a new line', () => {
+    const source = 'gitGraph tb options { test: true }\ncommit';
+    const normalized = normalizeMermaidSource(source);
+    expect(normalized.split('\n')[0]).toBe('gitGraph TB:');
+    expect(normalized.split('\n')[1]).toBe('options { test: true }');
+  });
+});

--- a/src/lib/mermaid/normalize.ts
+++ b/src/lib/mermaid/normalize.ts
@@ -9,17 +9,31 @@ export const normalizeMermaidSource = (value: string): string => {
   if (!unified) return '';
 
   const lines = unified.split('\n');
-  const headerPattern = /^\s*(flowchart|graph)\s+([A-Za-z]{2})(.*)$/i;
-  const headerMatch = lines[0].match(headerPattern);
+  const flowchartHeaderPattern = /^\s*(flowchart|graph)\s+([A-Za-z]{2})(.*)$/i;
+  const flowchartHeaderMatch = lines[0].match(flowchartHeaderPattern);
 
-  if (headerMatch) {
-    const [, keyword, orientation, rest] = headerMatch;
+  if (flowchartHeaderMatch) {
+    const [, keyword, orientation, rest] = flowchartHeaderMatch;
     lines[0] = `${keyword} ${orientation.toUpperCase()}`;
     if (rest && rest.trim().length > 0) {
       lines.splice(1, 0, rest.trim());
     }
   } else {
-    lines[0] = lines[0].trim();
+    const gitGraphHeaderPattern = /^\s*(gitgraph)\b(?:\s+([A-Za-z]{2}))?\s*:?(.*)$/i;
+    const gitGraphHeaderMatch = lines[0].match(gitGraphHeaderPattern);
+
+    if (gitGraphHeaderMatch) {
+      const [, keyword, orientation, rest] = gitGraphHeaderMatch;
+      const normalizedOrientation = orientation ? orientation.toUpperCase() : 'LR';
+      const headerLine = `${keyword} ${normalizedOrientation}:`;
+      lines[0] = headerLine;
+      const remainder = rest?.trim();
+      if (remainder) {
+        lines.splice(1, 0, remainder);
+      }
+    } else {
+      lines[0] = lines[0].trim();
+    }
   }
 
   return lines

--- a/src/lib/mermaid/serializer.ts
+++ b/src/lib/mermaid/serializer.ts
@@ -386,7 +386,7 @@ const serializeGitGraph = (model: MermaidGraphModel): MermaidSerializationResult
   const config = model.config.type === 'gitGraph' ? model.config : diagramDefinitions.gitGraph.defaultConfig;
   const warnings: string[] = [];
   const orientation = config.orientation ?? 'LR';
-  const lines: string[] = [`gitGraph ${orientation}`];
+  const lines: string[] = [`gitGraph ${orientation}:`];
 
   const orderMap = new Map<string, number>();
   model.nodes.forEach((node, index) => {


### PR DESCRIPTION
## Summary
- normalize gitGraph headers so colonless GUI output still renders without parser errors
- add regression tests covering gitGraph header normalization behavior

## Testing
- npm run test -- normalize

------
https://chatgpt.com/codex/tasks/task_e_68e1391256dc832f80e17f3d62c52478