### PR TITLE
Enable draggable sidebar widths and Git history height

### DIFF
--- a/src/components/layout/ResizableSidebar.tsx
+++ b/src/components/layout/ResizableSidebar.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef } from 'react';
+
+type SidebarHandlePosition = 'left' | 'right';
+
+interface ResizableSidebarProps {
+  width: number;
+  minWidth?: number;
+  maxWidth?: number;
+  onResize?: (width: number) => void;
+  onResizeEnd?: (width: number) => void;
+  className?: string;
+  handleClassName?: string;
+  children: React.ReactNode;
+  handlePosition?: SidebarHandlePosition;
+}
+
+const clamp = (value: number, min: number, max: number) => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
+  width,
+  minWidth = 200,
+  maxWidth = 600,
+  onResize,
+  onResizeEnd,
+  className = '',
+  handleClassName = '',
+  children,
+  handlePosition = 'right',
+}) => {
+  const widthRef = useRef(width);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    widthRef.current = width;
+  }, [width]);
+
+  const startDragging = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = widthRef.current;
+      const direction = handlePosition === 'right' ? 1 : -1;
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const deltaX = moveEvent.clientX - startX;
+        const nextWidth = clamp(startWidth + direction * deltaX, minWidth, maxWidth);
+
+        if (frameRef.current !== null) {
+          cancelAnimationFrame(frameRef.current);
+        }
+
+        frameRef.current = requestAnimationFrame(() => {
+          widthRef.current = nextWidth;
+          onResize?.(nextWidth);
+        });
+      };
+
+      const handlePointerUp = () => {
+        if (frameRef.current !== null) {
+          cancelAnimationFrame(frameRef.current);
+          frameRef.current = null;
+        }
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
+        document.body.style.userSelect = '';
+        onResizeEnd?.(widthRef.current);
+      };
+
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+      document.body.style.userSelect = 'none';
+    },
+    [handlePosition, maxWidth, minWidth, onResize, onResizeEnd],
+  );
+
+  return (
+    <div
+      className={`relative flex-shrink-0 overflow-hidden ${className}`}
+      style={{ width: `${width}px` }}
+    >
+      <div className="h-full w-full overflow-hidden">{children}</div>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        tabIndex={0}
+        onPointerDown={startDragging}
+        className={`absolute top-0 ${
+          handlePosition === 'right' ? 'right-0' : 'left-0'
+        } h-full w-2 cursor-col-resize touch-none select-none ${handleClassName}`}
+      >
+        <div className="relative flex h-full items-center justify-center">
+          <div className="h-12 w-px rounded bg-gray-300 dark:bg-gray-600" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResizableSidebar;

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_SIDEBAR_WIDTHS = {
+  explorer: 256,
+  gis: 288,
+  git: 384,
+  help: 384,
+  search: 320,
+} as const;
+
+export const DEFAULT_GIT_HISTORY_HEIGHT = 256;
+export const MIN_GIT_HISTORY_HEIGHT = 160;
+export const MIN_GIT_PANEL_MAIN_HEIGHT = 200;

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -4,6 +4,10 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createId } from '@/lib/utils/id';
 import {
+  DEFAULT_GIT_HISTORY_HEIGHT,
+  DEFAULT_SIDEBAR_WIDTHS,
+} from '@/constants/layout';
+import {
   TabData,
   FileTreeItem,
   EditorSettings,
@@ -274,6 +278,8 @@ export const useEditorStore = create<EditorStore>()(
         isAnalysisVisible: false,
         isGitVisible: false,
         isHelpVisible: false,
+        sidebarWidths: { ...DEFAULT_SIDEBAR_WIDTHS },
+        gitHistoryHeight: DEFAULT_GIT_HISTORY_HEIGHT,
       },
       updatePaneState: (state) => set((prevState) => ({
         paneState: { ...prevState.paneState, ...state }
@@ -749,6 +755,8 @@ export const useEditorStore = create<EditorStore>()(
               isAnalysisVisible: false,
               isGitVisible: false,
               isHelpVisible: false,
+              sidebarWidths: { ...DEFAULT_SIDEBAR_WIDTHS },
+              gitHistoryHeight: DEFAULT_GIT_HISTORY_HEIGHT,
             };
           } else {
             if (typeof state.paneState.activeSidebar === 'undefined') {
@@ -769,6 +777,14 @@ export const useEditorStore = create<EditorStore>()(
             }
             if (typeof state.paneState.isHelpVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isHelpVisible: false };
+            }
+            const nextSidebarWidths = {
+              ...DEFAULT_SIDEBAR_WIDTHS,
+              ...(state.paneState.sidebarWidths ?? {}),
+            };
+            state.paneState = { ...state.paneState, sidebarWidths: nextSidebarWidths };
+            if (typeof state.paneState.gitHistoryHeight !== 'number') {
+              state.paneState = { ...state.paneState, gitHistoryHeight: DEFAULT_GIT_HISTORY_HEIGHT };
             }
           }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,6 +93,14 @@ export interface PaneState {
   isAnalysisVisible: boolean;
   isGitVisible: boolean;
   isHelpVisible: boolean;
+  sidebarWidths: {
+    explorer: number;
+    gis: number;
+    git: number;
+    help: number;
+    search: number;
+  };
+  gitHistoryHeight: number;
 }
 
 // コンテキストメニューに関する型定義


### PR DESCRIPTION
## Summary
- add a reusable resizable sidebar wrapper and apply it to explorer, GIS, Git, help, and search panels so their widths can be changed with the mouse
- persist sidebar width settings and Git history pane height in the editor store for consistent sizing across sessions
- add a draggable splitter to the Git history section so users can control the height of the history list within the sidebar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e13fcfa374832fbcef028625fa9e4a