### PR TITLE
Add in-app browser panel with AI quick links

### DIFF
--- a/src/components/browser/BrowserPanel.tsx
+++ b/src/components/browser/BrowserPanel.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IoReloadOutline, IoReturnDownForwardOutline } from 'react-icons/io5';
+
+const DEFAULT_URL = 'https://www.google.com/';
+
+const QUICK_LINKS: { label: string; url: string }[] = [
+  { label: 'Google', url: 'https://www.google.com/' },
+  { label: 'Google Gemini', url: 'https://gemini.google.com/app' },
+  { label: 'ChatGPT', url: 'https://chatgpt.com/' },
+];
+
+const normalizeUrl = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_URL;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+};
+
+const BrowserPanel: React.FC = () => {
+  const [urlInput, setUrlInput] = useState(DEFAULT_URL);
+  const [currentUrl, setCurrentUrl] = useState(DEFAULT_URL);
+  const [isLoading, setIsLoading] = useState(true);
+  const [iframeKey, setIframeKey] = useState(() => Date.now());
+
+  const hostLabel = useMemo(() => {
+    try {
+      const parsed = new URL(currentUrl);
+      return parsed.hostname;
+    } catch {
+      return currentUrl;
+    }
+  }, [currentUrl]);
+
+  const navigateTo = useCallback((nextUrl: string) => {
+    setCurrentUrl(nextUrl);
+    setUrlInput(nextUrl);
+    setIsLoading(true);
+    setIframeKey(Date.now());
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      navigateTo(normalizeUrl(urlInput));
+    },
+    [navigateTo, urlInput],
+  );
+
+  const handleQuickLink = useCallback(
+    (url: string) => {
+      navigateTo(url);
+    },
+    [navigateTo],
+  );
+
+  const handleReload = useCallback(() => {
+    setIframeKey(Date.now());
+    setIsLoading(true);
+  }, []);
+
+  useEffect(() => {
+    setIsLoading(true);
+  }, [currentUrl]);
+
+  return (
+    <div className="flex h-full flex-col bg-gray-50 dark:bg-slate-950">
+      <div className="border-b border-gray-200 bg-white px-3 py-2 dark:border-gray-800 dark:bg-slate-900">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleReload}
+            className="flex h-9 w-9 items-center justify-center rounded border border-gray-300 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            title="再読み込み"
+            aria-label="再読み込み"
+          >
+            <IoReloadOutline size={18} />
+          </button>
+          <input
+            className="h-9 flex-1 rounded border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-slate-950 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400/40"
+            value={urlInput}
+            onChange={(event) => setUrlInput(event.target.value)}
+            placeholder="https://"
+            spellCheck={false}
+            aria-label="URL入力"
+          />
+          <button
+            type="submit"
+            className="flex h-9 items-center gap-1 rounded border border-blue-500 bg-blue-500 px-3 text-sm font-medium text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+          >
+            <IoReturnDownForwardOutline size={18} />
+            開く
+          </button>
+        </form>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {QUICK_LINKS.map((link) => (
+            <button
+              key={link.url}
+              type="button"
+              onClick={() => handleQuickLink(link.url)}
+              className="rounded-full border border-transparent bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700"
+            >
+              {link.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 border-b border-gray-200 px-3 py-2 text-xs text-gray-600 dark:border-gray-800 dark:text-gray-300">
+        <span className="font-medium">現在のサイト: {hostLabel}</span>
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          一部のサイトはセキュリティのため埋め込み表示を許可しておらず、空白になる場合があります。その際はヘッダーのリンクから直接アクセスしてください。
+        </span>
+      </div>
+      <div className="relative flex-1 overflow-hidden">
+        <iframe
+          key={iframeKey}
+          src={currentUrl}
+          title="ブラウザビュー"
+          className="h-full w-full border-0 bg-white dark:bg-slate-900"
+          onLoad={() => setIsLoading(false)}
+          allow="clipboard-read; clipboard-write; geolocation *; microphone *; camera *; autoplay *"
+        />
+        {isLoading && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-slate-950/60">
+            <div className="rounded-full border border-gray-300 bg-white px-4 py-1 text-sm font-medium text-gray-700 shadow dark:border-gray-700 dark:bg-slate-900 dark:text-gray-200">
+              読み込み中...
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BrowserPanel;

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -3,13 +3,14 @@
 import React from 'react';
 import {
   IoFolderOpenOutline,
+  IoBrowsersOutline,
   IoGlobeOutline,
   IoGitBranchOutline,
   IoChatbubblesOutline,
   IoGitMergeOutline,
 } from 'react-icons/io5';
 
-type ActivityItem = 'explorer' | 'gis' | 'git' | 'help';
+type ActivityItem = 'explorer' | 'browser' | 'gis' | 'git' | 'help';
 
 interface ActivityBarProps {
   activeItem: ActivityItem | null;
@@ -43,6 +44,15 @@ const ActivityBar: React.FC<ActivityBarProps> = ({
         aria-pressed={activeItem === 'explorer'}
       >
         <IoFolderOpenOutline size={20} />
+      </button>
+      <button
+        type="button"
+        className={`${baseButton} mt-2 ${activeItem === 'browser' ? activeClass : inactiveClass}`}
+        onClick={() => onSelect('browser')}
+        title="ブラウザ"
+        aria-pressed={activeItem === 'browser'}
+      >
+        <IoBrowsersOutline size={20} />
       </button>
       {multiFileAnalysisAvailable && (
         <button

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -12,7 +12,9 @@ import {
   IoDownloadOutline,
   IoKeyOutline,
   IoHelpCircleOutline,
+  IoBrowsersOutline,
 } from 'react-icons/io5';
+import { SiGooglegemini, SiOpenai } from 'react-icons/si';
 
 interface MainHeaderProps {
   onToggleExplorer: () => void;
@@ -23,6 +25,8 @@ interface MainHeaderProps {
   onToggleTheme: () => void;
   onNewFile: () => void;
   onToggleSearch: () => void;
+  onToggleBrowser: () => void;
+  isBrowserPaneVisible: boolean;
   multiFileAnalysisEnabled: boolean;
   onToggleMultiFileAnalysis: () => void;
   selectedFileCount: number;
@@ -44,6 +48,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleTheme,
   onNewFile,
   onToggleSearch,
+  onToggleBrowser,
+  isBrowserPaneVisible,
   multiFileAnalysisEnabled,
   onToggleMultiFileAnalysis,
   selectedFileCount,
@@ -117,6 +123,16 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         <IoSearch size={20} />
       </button>
       <button
+        className={`p-1 rounded ml-2 ${
+          isBrowserPaneVisible ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+        }`}
+        onClick={onToggleBrowser}
+        aria-label="Toggle Browser Panel"
+        title={`ブラウザパネル ${isBrowserPaneVisible ? '表示中' : '非表示'}`}
+      >
+        <IoBrowsersOutline size={20} />
+      </button>
+      <button
         className="p-1 rounded hover:bg-gray-200 ml-2 dark:hover:bg-gray-800"
         onClick={onOpenLlmSettings}
         aria-label="AI設定"
@@ -161,6 +177,28 @@ const MainHeader: React.FC<MainHeaderProps> = ({
           </span>
         )}
       </button>
+      <div className="ml-3 flex items-center space-x-2">
+        <a
+          href="https://gemini.google.com/app"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1 rounded text-gray-600 transition hover:bg-gray-200 hover:text-blue-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
+          title="Google Gemini を開く"
+          aria-label="Google Gemini へアクセス"
+        >
+          <SiGooglegemini size={20} />
+        </a>
+        <a
+          href="https://chatgpt.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1 rounded text-gray-600 transition hover:bg-gray-200 hover:text-green-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-green-300"
+          title="ChatGPT を開く"
+          aria-label="ChatGPT へアクセス"
+        >
+          <SiOpenai size={20} />
+        </a>
+      </div>
     </header>
   );
 };

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -102,6 +102,7 @@ const MainLayoutContent: React.FC = () => {
     (pane: keyof typeof paneState) => {
       if (
         pane === 'isExplorerVisible' ||
+        pane === 'isBrowserVisible' ||
         pane === 'isGisVisible' ||
         pane === 'isGitVisible' ||
         pane === 'isHelpVisible' ||
@@ -119,6 +120,19 @@ const MainLayoutContent: React.FC = () => {
     updatePaneState({
       activeSidebar: isActive ? null : 'explorer',
       isExplorerVisible: !isActive,
+      isBrowserVisible: false,
+      isGisVisible: false,
+      isGitVisible: false,
+      isHelpVisible: false,
+    });
+  }, [paneState.activeSidebar, updatePaneState]);
+
+  const handleToggleBrowserPane = useCallback(() => {
+    const isActive = paneState.activeSidebar === 'browser';
+    updatePaneState({
+      activeSidebar: isActive ? null : 'browser',
+      isBrowserVisible: !isActive,
+      isExplorerVisible: false,
       isGisVisible: false,
       isGitVisible: false,
       isHelpVisible: false,
@@ -132,6 +146,7 @@ const MainLayoutContent: React.FC = () => {
       isGitVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isHelpVisible: false,
     });
   }, [paneState.activeSidebar, updatePaneState]);
@@ -146,6 +161,7 @@ const MainLayoutContent: React.FC = () => {
       isHelpVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isGitVisible: false,
     });
   }, [aiFeaturesEnabled, paneState.activeSidebar, updatePaneState]);
@@ -515,6 +531,8 @@ const MainLayoutContent: React.FC = () => {
         onToggleTheme={handleToggleTheme}
         onNewFile={() => setShowNewFileDialog(true)}
         onToggleSearch={() => togglePane('isSearchVisible')}
+        onToggleBrowser={handleToggleBrowserPane}
+        isBrowserPaneVisible={paneState.isBrowserVisible}
         multiFileAnalysisEnabled={multiFileAnalysisEnabled}
         onToggleMultiFileAnalysis={handleToggleMultiFile}
         selectedFileCount={selectedFiles.size}

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -22,6 +22,7 @@ import GitCommitDiffView from '@/components/git/GitCommitDiffView';
 import HelpSidebar from '@/components/help/HelpSidebar';
 import ResizableSidebar from '@/components/layout/ResizableSidebar';
 import { DEFAULT_SIDEBAR_WIDTHS } from '@/constants/layout';
+import BrowserPanel from '@/components/browser/BrowserPanel';
 
 interface WorkspaceProps {
   paneState: PaneState;
@@ -51,6 +52,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
   const [isScrollSyncEnabled, setIsScrollSyncEnabled] = useState(false);
   const [sidebarWidths, setSidebarWidths] = useState({
     explorer: paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer,
+    browser: paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser,
     gis: paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis,
     git: paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git,
     help: paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help,
@@ -59,6 +61,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
 
   useEffect(() => {
     const nextExplorer = paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer;
+    const nextBrowser = paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser;
     const nextGis = paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis;
     const nextGit = paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git;
     const nextHelp = paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help;
@@ -67,6 +70,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
     setSidebarWidths((previous) => {
       if (
         previous.explorer === nextExplorer &&
+        previous.browser === nextBrowser &&
         previous.gis === nextGis &&
         previous.git === nextGit &&
         previous.help === nextHelp &&
@@ -76,13 +80,21 @@ const Workspace: React.FC<WorkspaceProps> = ({
       }
       return {
         explorer: nextExplorer,
+        browser: nextBrowser,
         gis: nextGis,
         git: nextGit,
         help: nextHelp,
         search: nextSearch,
       };
     });
-  }, [paneState.sidebarWidths?.explorer, paneState.sidebarWidths?.gis, paneState.sidebarWidths?.git, paneState.sidebarWidths?.help, paneState.sidebarWidths?.search]);
+  }, [
+    paneState.sidebarWidths?.explorer,
+    paneState.sidebarWidths?.browser,
+    paneState.sidebarWidths?.gis,
+    paneState.sidebarWidths?.git,
+    paneState.sidebarWidths?.help,
+    paneState.sidebarWidths?.search,
+  ]);
 
   type SidebarKey = keyof typeof DEFAULT_SIDEBAR_WIDTHS;
 
@@ -151,6 +163,9 @@ const Workspace: React.FC<WorkspaceProps> = ({
     if (paneState.isExplorerVisible) {
       return 'explorer';
     }
+    if (paneState.isBrowserVisible) {
+      return 'browser';
+    }
     if (paneState.isGitVisible) {
       return 'git';
     }
@@ -161,15 +176,23 @@ const Workspace: React.FC<WorkspaceProps> = ({
       return 'help';
     }
     return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
+  }, [
+    paneState.activeSidebar,
+    paneState.isExplorerVisible,
+    paneState.isBrowserVisible,
+    paneState.isGitVisible,
+    paneState.isGisVisible,
+    paneState.isHelpVisible,
+  ]);
 
   const showExplorer = activeSidebar === 'explorer';
+  const showBrowserSidebar = activeSidebar === 'browser';
   const showGitSidebar = activeSidebar === 'git';
   const showGisSidebar = activeSidebar === 'gis';
   const showHelpSidebar = aiFeaturesEnabled && activeSidebar === 'help';
 
   const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
+    (sidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help') => {
       if (sidebar === 'help' && !aiFeaturesEnabled) {
         return;
       }
@@ -177,6 +200,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
       updatePaneState({
         activeSidebar: isActive ? null : sidebar,
         isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
+        isBrowserVisible: sidebar === 'browser' ? !isActive : false,
         isGisVisible: sidebar === 'gis' ? !isActive : false,
         isGitVisible: sidebar === 'git' ? !isActive : false,
         isHelpVisible: sidebar === 'help' ? !isActive : false,
@@ -439,6 +463,19 @@ const Workspace: React.FC<WorkspaceProps> = ({
           handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
         >
           <FileExplorer />
+        </ResizableSidebar>
+      )}
+      {showBrowserSidebar && (
+        <ResizableSidebar
+          width={sidebarWidths.browser}
+          minWidth={280}
+          maxWidth={720}
+          onResize={(width) => handleSidebarResize('browser', width)}
+          onResizeEnd={(width) => handleSidebarResizeEnd('browser', width)}
+          className="border-r border-gray-200 dark:border-gray-800 overflow-hidden"
+          handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
+        >
+          <BrowserPanel />
         </ResizableSidebar>
       )}
       {showGisSidebar && (

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_SIDEBAR_WIDTHS = {
   explorer: 256,
+  browser: 420,
   gis: 288,
   git: 384,
   help: 384,

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -270,6 +270,7 @@ export const useEditorStore = create<EditorStore>()(
       paneState: {
         activeSidebar: 'explorer',
         isExplorerVisible: true,
+        isBrowserVisible: false,
         isGisVisible: false,
         isEditorVisible: true,
         isPreviewVisible: true,
@@ -747,6 +748,7 @@ export const useEditorStore = create<EditorStore>()(
             state.paneState = {
               activeSidebar: 'explorer',
               isExplorerVisible: true,
+              isBrowserVisible: false,
               isGisVisible: false,
               isEditorVisible: true,
               isPreviewVisible: true,
@@ -762,10 +764,14 @@ export const useEditorStore = create<EditorStore>()(
             if (typeof state.paneState.activeSidebar === 'undefined') {
               const inferredSidebar = state.paneState.isExplorerVisible
                 ? 'explorer'
+                : state.paneState.isBrowserVisible
+                  ? 'browser'
                 : state.paneState.isGisVisible
                   ? 'gis'
                 : state.paneState.isGitVisible
                   ? 'git'
+                : state.paneState.isHelpVisible
+                  ? 'help'
                   : null;
               state.paneState = { ...state.paneState, activeSidebar: inferredSidebar };
             }
@@ -774,6 +780,9 @@ export const useEditorStore = create<EditorStore>()(
             }
             if (typeof state.paneState.isGitVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isGitVisible: false };
+            }
+            if (typeof state.paneState.isBrowserVisible !== 'boolean') {
+              state.paneState = { ...state.paneState, isBrowserVisible: false };
             }
             if (typeof state.paneState.isHelpVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isHelpVisible: false };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,8 +83,9 @@ export interface EditorSettings {
 
 // パネル表示状態に関する型定義
 export interface PaneState {
-  activeSidebar: 'explorer' | 'gis' | 'git' | 'help' | null;
+  activeSidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help' | null;
   isExplorerVisible: boolean;
+  isBrowserVisible: boolean;
   isGisVisible: boolean;
   isEditorVisible: boolean;
   isPreviewVisible: boolean;
@@ -95,6 +96,7 @@ export interface PaneState {
   isHelpVisible: boolean;
   sidebarWidths: {
     explorer: number;
+    browser: number;
     gis: number;
     git: number;
     help: number;


### PR DESCRIPTION
## Summary
- add a dedicated browser sidebar panel with navigation controls and quick links for common AI tools
- expose the browser panel through the activity bar and header alongside new external links to Google Gemini and ChatGPT
- persist browser sidebar layout metadata and update pane state defaults for existing users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e25c97394c832f876f53b6e4f034e6