### PR TITLE
Add Google Drive shortcut and sync browser state

### DIFF
--- a/src/components/browser/BrowserPanel.tsx
+++ b/src/components/browser/BrowserPanel.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IoReloadOutline, IoReturnDownForwardOutline } from 'react-icons/io5';
+import { DEFAULT_BROWSER_URL, useEditorStore } from '@/store/editorStore';
+
+const DEFAULT_URL = DEFAULT_BROWSER_URL;
+
+const QUICK_LINKS: { label: string; url: string }[] = [
+  { label: 'Google', url: DEFAULT_BROWSER_URL },
+  { label: 'Google Drive', url: 'https://drive.google.com/drive/u/0/my-drive' },
+];
+
+const normalizeUrl = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_URL;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+};
+
+const BLOCKED_HOSTNAMES = new Set<string>(['chatgpt.com', 'gemini.google.com']);
+
+const BLOCKED_HOST_MESSAGES: Record<string, string> = {
+  'chatgpt.com':
+    'ChatGPT は X-Frame-Options などのポリシーで外部サイトからの埋め込みを禁止しているため、このパネル内では表示できません。',
+  'gemini.google.com':
+    'Google Gemini は厳格な CSP (Content-Security-Policy) を設定しており、別サイトから iframe で読み込むことができません。',
+};
+
+const BrowserPanel: React.FC = () => {
+  const browserUrl = useEditorStore((state) => state.browserUrl);
+  const setBrowserUrl = useEditorStore((state) => state.setBrowserUrl);
+  const [urlInput, setUrlInput] = useState(browserUrl || DEFAULT_URL);
+  const [currentUrl, setCurrentUrl] = useState(browserUrl || DEFAULT_URL);
+  const [isLoading, setIsLoading] = useState(true);
+  const [iframeKey, setIframeKey] = useState(() => Date.now());
+
+  const hostLabel = useMemo(() => {
+    try {
+      const parsed = new URL(currentUrl);
+      return parsed.hostname;
+    } catch {
+      return currentUrl;
+    }
+  }, [currentUrl]);
+
+  const { isLikelyBlocked, blockedDescription } = useMemo(() => {
+    try {
+      const { hostname } = new URL(currentUrl);
+      if (!BLOCKED_HOSTNAMES.has(hostname)) {
+        return { isLikelyBlocked: false, blockedDescription: '' };
+      }
+
+      return {
+        isLikelyBlocked: true,
+        blockedDescription:
+          BLOCKED_HOST_MESSAGES[hostname] ??
+          'このサイトは埋め込み表示をサポートしていないため、直接アクセスする必要があります。',
+      };
+    } catch {
+      return { isLikelyBlocked: false, blockedDescription: '' };
+    }
+  }, [currentUrl]);
+
+  useEffect(() => {
+    const nextUrl = browserUrl || DEFAULT_URL;
+    setCurrentUrl(nextUrl);
+    setUrlInput(nextUrl);
+    setIsLoading(true);
+    setIframeKey(Date.now());
+  }, [browserUrl]);
+
+  const navigateTo = useCallback(
+    (nextUrl: string) => {
+      setBrowserUrl(nextUrl);
+    },
+    [setBrowserUrl],
+  );
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      navigateTo(normalizeUrl(urlInput));
+    },
+    [navigateTo, urlInput],
+  );
+
+  const handleQuickLink = useCallback(
+    (url: string) => {
+      navigateTo(url);
+    },
+    [navigateTo],
+  );
+
+  const handleReload = useCallback(() => {
+    setIframeKey(Date.now());
+    setIsLoading(true);
+  }, []);
+
+  useEffect(() => {
+    if (isLikelyBlocked) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+  }, [currentUrl, isLikelyBlocked]);
+
+  const handleOpenExternally = useCallback(() => {
+    if (!currentUrl) {
+      return;
+    }
+
+    window.open(currentUrl, '_blank', 'noopener,noreferrer');
+  }, [currentUrl]);
+
+  return (
+    <div className="flex h-full flex-col bg-gray-50 dark:bg-slate-950">
+      <div className="border-b border-gray-200 bg-white px-3 py-2 dark:border-gray-800 dark:bg-slate-900">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleReload}
+            className="flex h-9 w-9 items-center justify-center rounded border border-gray-300 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            title="再読み込み"
+            aria-label="再読み込み"
+          >
+            <IoReloadOutline size={18} />
+          </button>
+          <input
+            className="h-9 flex-1 rounded border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-slate-950 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400/40"
+            value={urlInput}
+            onChange={(event) => setUrlInput(event.target.value)}
+            placeholder="https://"
+            spellCheck={false}
+            aria-label="URL入力"
+          />
+          <button
+            type="submit"
+            className="flex h-9 items-center gap-1 rounded border border-blue-500 bg-blue-500 px-3 text-sm font-medium text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+          >
+            <IoReturnDownForwardOutline size={18} />
+            開く
+          </button>
+        </form>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {QUICK_LINKS.map((link) => (
+            <button
+              key={link.url}
+              type="button"
+              onClick={() => handleQuickLink(link.url)}
+              className="rounded-full border border-transparent bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700"
+            >
+              {link.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 border-b border-gray-200 px-3 py-2 text-xs text-gray-600 dark:border-gray-800 dark:text-gray-300">
+        <span className="font-medium">現在のサイト: {hostLabel}</span>
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          一部のサイト（ChatGPT や Google Gemini など）はセキュリティポリシーにより iframe での表示が禁止されています。その場合はヘッダーのショートカットまたは「新しいタブで開く」から直接アクセスしてください。
+        </span>
+      </div>
+      <div className="relative flex-1 overflow-hidden">
+        <iframe
+          key={iframeKey}
+          src={currentUrl}
+          title="ブラウザビュー"
+          className="h-full w-full border-0 bg-white dark:bg-slate-900"
+          onLoad={() => setIsLoading(false)}
+          allow="clipboard-read; clipboard-write; geolocation *; microphone *; camera *; autoplay *"
+        />
+        {isLikelyBlocked && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/90 px-4 text-center text-sm text-gray-700 dark:bg-slate-950/90 dark:text-gray-200">
+            <p className="font-medium">このサイトは埋め込み表示が制限されています。</p>
+            <p className="max-w-xs text-xs text-gray-500 dark:text-gray-400">
+              {blockedDescription ||
+                '安全性の理由から iframe 内で読み込めない場合があります。下のボタンからブラウザで開いてください。'}
+            </p>
+            <button
+              type="button"
+              onClick={handleOpenExternally}
+              className="rounded border border-blue-500 bg-blue-500 px-4 py-1.5 text-xs font-medium text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              新しいタブで開く
+            </button>
+          </div>
+        )}
+        {isLoading && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-slate-950/60">
+            <div className="rounded-full border border-gray-300 bg-white px-4 py-1 text-sm font-medium text-gray-700 shadow dark:border-gray-700 dark:bg-slate-900 dark:text-gray-200">
+              読み込み中...
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BrowserPanel;

--- a/src/components/explorer/FileExplorer.tsx
+++ b/src/components/explorer/FileExplorer.tsx
@@ -54,26 +54,29 @@ import type { MermaidDiagramType } from '@/lib/mermaid/types';
  * - 右クリックメニューによる操作
  * - ダイアログによる入力・確認
  */
+const GOOGLE_DRIVE_URL = 'https://drive.google.com/drive/u/0/my-drive';
+
 const FileExplorer = () => {
   const {
     rootFileTree,
     rootDirHandle,
     rootFolderName,
     setRootDirHandle,
-    setRootFileTree, 
+    setRootFileTree,
     setRootFolderName,
     addTab,
     addTempTab,
     activeTabId,
     setActiveTabId,
-  updateTab,
+    updateTab,
     tabs,
     setContextMenuTarget,
     contextMenuTarget,
     multiFileAnalysisEnabled,
     selectedFiles,
     addSelectedFile,
-    removeSelectedFile
+    removeSelectedFile,
+    openBrowserWithUrl,
   } = useEditorStore();
   const setGitRootDirectory = useGitStore((state) => state.setRootDirectory);
   // Avoid returning an object literal from the selector which creates a new
@@ -183,6 +186,10 @@ const FileExplorer = () => {
       alert(`フォルダの選択中にエラーが発生しました: ${error instanceof Error ? error.message : '不明なエラー'}`);
     }
   };
+
+  const handleOpenGoogleDrive = useCallback(() => {
+    openBrowserWithUrl(GOOGLE_DRIVE_URL);
+  }, [openBrowserWithUrl]);
   
   // フォルダの展開状態を切り替え
   const toggleFolder = (path: string) => {
@@ -799,6 +806,21 @@ const FileExplorer = () => {
       
       {/* ファイルツリー */}
       <div className="flex-1 overflow-auto">
+        <div className="border-b border-gray-300 bg-white px-3 py-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-gray-700 dark:text-gray-100">クラウドストレージ</span>
+            <button
+              className="rounded border border-blue-500 bg-blue-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+              type="button"
+              onClick={handleOpenGoogleDrive}
+            >
+              Google Drive を開く
+            </button>
+          </div>
+          <p className="mt-2 leading-relaxed">
+            Google Drive は組み込みブラウザで開きます。最初に Google アカウントでのログインが必要な場合があります。
+          </p>
+        </div>
         {rootFileTree ? (
           <div className="py-1 text-sm">
             {renderFileTree(rootFileTree)}

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -3,13 +3,14 @@
 import React from 'react';
 import {
   IoFolderOpenOutline,
+  IoBrowsersOutline,
   IoGlobeOutline,
   IoGitBranchOutline,
   IoChatbubblesOutline,
   IoGitMergeOutline,
 } from 'react-icons/io5';
 
-type ActivityItem = 'explorer' | 'gis' | 'git' | 'help';
+type ActivityItem = 'explorer' | 'browser' | 'gis' | 'git' | 'help';
 
 interface ActivityBarProps {
   activeItem: ActivityItem | null;
@@ -43,6 +44,15 @@ const ActivityBar: React.FC<ActivityBarProps> = ({
         aria-pressed={activeItem === 'explorer'}
       >
         <IoFolderOpenOutline size={20} />
+      </button>
+      <button
+        type="button"
+        className={`${baseButton} mt-2 ${activeItem === 'browser' ? activeClass : inactiveClass}`}
+        onClick={() => onSelect('browser')}
+        title="ブラウザ"
+        aria-pressed={activeItem === 'browser'}
+      >
+        <IoBrowsersOutline size={20} />
       </button>
       {multiFileAnalysisAvailable && (
         <button

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -12,6 +12,7 @@ import {
   IoDownloadOutline,
   IoKeyOutline,
   IoHelpCircleOutline,
+  IoBrowsersOutline,
 } from 'react-icons/io5';
 
 interface MainHeaderProps {
@@ -23,6 +24,8 @@ interface MainHeaderProps {
   onToggleTheme: () => void;
   onNewFile: () => void;
   onToggleSearch: () => void;
+  onToggleBrowser: () => void;
+  isBrowserPaneVisible: boolean;
   multiFileAnalysisEnabled: boolean;
   onToggleMultiFileAnalysis: () => void;
   selectedFileCount: number;
@@ -44,6 +47,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleTheme,
   onNewFile,
   onToggleSearch,
+  onToggleBrowser,
+  isBrowserPaneVisible,
   multiFileAnalysisEnabled,
   onToggleMultiFileAnalysis,
   selectedFileCount,
@@ -115,6 +120,16 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         aria-label="Toggle Search"
       >
         <IoSearch size={20} />
+      </button>
+      <button
+        className={`p-1 rounded ml-2 ${
+          isBrowserPaneVisible ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+        }`}
+        onClick={onToggleBrowser}
+        aria-label="Toggle Browser Panel"
+        title={`ブラウザパネル ${isBrowserPaneVisible ? '表示中' : '非表示'}`}
+      >
+        <IoBrowsersOutline size={20} />
       </button>
       <button
         className="p-1 rounded hover:bg-gray-200 ml-2 dark:hover:bg-gray-800"

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -102,6 +102,7 @@ const MainLayoutContent: React.FC = () => {
     (pane: keyof typeof paneState) => {
       if (
         pane === 'isExplorerVisible' ||
+        pane === 'isBrowserVisible' ||
         pane === 'isGisVisible' ||
         pane === 'isGitVisible' ||
         pane === 'isHelpVisible' ||
@@ -119,6 +120,19 @@ const MainLayoutContent: React.FC = () => {
     updatePaneState({
       activeSidebar: isActive ? null : 'explorer',
       isExplorerVisible: !isActive,
+      isBrowserVisible: false,
+      isGisVisible: false,
+      isGitVisible: false,
+      isHelpVisible: false,
+    });
+  }, [paneState.activeSidebar, updatePaneState]);
+
+  const handleToggleBrowserPane = useCallback(() => {
+    const isActive = paneState.activeSidebar === 'browser';
+    updatePaneState({
+      activeSidebar: isActive ? null : 'browser',
+      isBrowserVisible: !isActive,
+      isExplorerVisible: false,
       isGisVisible: false,
       isGitVisible: false,
       isHelpVisible: false,
@@ -132,6 +146,7 @@ const MainLayoutContent: React.FC = () => {
       isGitVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isHelpVisible: false,
     });
   }, [paneState.activeSidebar, updatePaneState]);
@@ -146,6 +161,7 @@ const MainLayoutContent: React.FC = () => {
       isHelpVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isGitVisible: false,
     });
   }, [aiFeaturesEnabled, paneState.activeSidebar, updatePaneState]);
@@ -515,6 +531,8 @@ const MainLayoutContent: React.FC = () => {
         onToggleTheme={handleToggleTheme}
         onNewFile={() => setShowNewFileDialog(true)}
         onToggleSearch={() => togglePane('isSearchVisible')}
+        onToggleBrowser={handleToggleBrowserPane}
+        isBrowserPaneVisible={paneState.isBrowserVisible}
         multiFileAnalysisEnabled={multiFileAnalysisEnabled}
         onToggleMultiFileAnalysis={handleToggleMultiFile}
         selectedFileCount={selectedFiles.size}

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -22,6 +22,7 @@ import GitCommitDiffView from '@/components/git/GitCommitDiffView';
 import HelpSidebar from '@/components/help/HelpSidebar';
 import ResizableSidebar from '@/components/layout/ResizableSidebar';
 import { DEFAULT_SIDEBAR_WIDTHS } from '@/constants/layout';
+import BrowserPanel from '@/components/browser/BrowserPanel';
 
 interface WorkspaceProps {
   paneState: PaneState;
@@ -51,6 +52,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
   const [isScrollSyncEnabled, setIsScrollSyncEnabled] = useState(false);
   const [sidebarWidths, setSidebarWidths] = useState({
     explorer: paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer,
+    browser: paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser,
     gis: paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis,
     git: paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git,
     help: paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help,
@@ -59,6 +61,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
 
   useEffect(() => {
     const nextExplorer = paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer;
+    const nextBrowser = paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser;
     const nextGis = paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis;
     const nextGit = paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git;
     const nextHelp = paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help;
@@ -67,6 +70,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
     setSidebarWidths((previous) => {
       if (
         previous.explorer === nextExplorer &&
+        previous.browser === nextBrowser &&
         previous.gis === nextGis &&
         previous.git === nextGit &&
         previous.help === nextHelp &&
@@ -76,13 +80,21 @@ const Workspace: React.FC<WorkspaceProps> = ({
       }
       return {
         explorer: nextExplorer,
+        browser: nextBrowser,
         gis: nextGis,
         git: nextGit,
         help: nextHelp,
         search: nextSearch,
       };
     });
-  }, [paneState.sidebarWidths?.explorer, paneState.sidebarWidths?.gis, paneState.sidebarWidths?.git, paneState.sidebarWidths?.help, paneState.sidebarWidths?.search]);
+  }, [
+    paneState.sidebarWidths?.explorer,
+    paneState.sidebarWidths?.browser,
+    paneState.sidebarWidths?.gis,
+    paneState.sidebarWidths?.git,
+    paneState.sidebarWidths?.help,
+    paneState.sidebarWidths?.search,
+  ]);
 
   type SidebarKey = keyof typeof DEFAULT_SIDEBAR_WIDTHS;
 
@@ -151,6 +163,9 @@ const Workspace: React.FC<WorkspaceProps> = ({
     if (paneState.isExplorerVisible) {
       return 'explorer';
     }
+    if (paneState.isBrowserVisible) {
+      return 'browser';
+    }
     if (paneState.isGitVisible) {
       return 'git';
     }
@@ -161,15 +176,23 @@ const Workspace: React.FC<WorkspaceProps> = ({
       return 'help';
     }
     return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
+  }, [
+    paneState.activeSidebar,
+    paneState.isExplorerVisible,
+    paneState.isBrowserVisible,
+    paneState.isGitVisible,
+    paneState.isGisVisible,
+    paneState.isHelpVisible,
+  ]);
 
   const showExplorer = activeSidebar === 'explorer';
+  const showBrowserSidebar = activeSidebar === 'browser';
   const showGitSidebar = activeSidebar === 'git';
   const showGisSidebar = activeSidebar === 'gis';
   const showHelpSidebar = aiFeaturesEnabled && activeSidebar === 'help';
 
   const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
+    (sidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help') => {
       if (sidebar === 'help' && !aiFeaturesEnabled) {
         return;
       }
@@ -177,6 +200,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
       updatePaneState({
         activeSidebar: isActive ? null : sidebar,
         isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
+        isBrowserVisible: sidebar === 'browser' ? !isActive : false,
         isGisVisible: sidebar === 'gis' ? !isActive : false,
         isGitVisible: sidebar === 'git' ? !isActive : false,
         isHelpVisible: sidebar === 'help' ? !isActive : false,
@@ -439,6 +463,19 @@ const Workspace: React.FC<WorkspaceProps> = ({
           handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
         >
           <FileExplorer />
+        </ResizableSidebar>
+      )}
+      {showBrowserSidebar && (
+        <ResizableSidebar
+          width={sidebarWidths.browser}
+          minWidth={280}
+          maxWidth={720}
+          onResize={(width) => handleSidebarResize('browser', width)}
+          onResizeEnd={(width) => handleSidebarResizeEnd('browser', width)}
+          className="border-r border-gray-200 dark:border-gray-800 overflow-hidden"
+          handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
+        >
+          <BrowserPanel />
         </ResizableSidebar>
       )}
       {showGisSidebar && (

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_SIDEBAR_WIDTHS = {
   explorer: 256,
+  browser: 420,
   gis: 288,
   git: 384,
   help: 384,

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -80,6 +80,11 @@ interface EditorStore {
   setIsSearching: (searching: boolean) => void;
   replaceText: string;
   setReplaceText: (text: string) => void;
+
+  // インアプリブラウザ
+  browserUrl: string;
+  setBrowserUrl: (url: string) => void;
+  openBrowserWithUrl: (url: string) => void;
   
   // 分析機能
   analysisEnabled: boolean;
@@ -139,6 +144,8 @@ interface EditorStore {
   helpSettings: HelpSettings;
   updateHelpSettings: (updates: Partial<HelpSettings>) => void;
 }
+
+export const DEFAULT_BROWSER_URL = 'https://www.google.com/';
 
 export const useEditorStore = create<EditorStore>()(
   persist(
@@ -270,6 +277,7 @@ export const useEditorStore = create<EditorStore>()(
       paneState: {
         activeSidebar: 'explorer',
         isExplorerVisible: true,
+        isBrowserVisible: false,
         isGisVisible: false,
         isEditorVisible: true,
         isPreviewVisible: true,
@@ -304,6 +312,19 @@ export const useEditorStore = create<EditorStore>()(
       setIsSearching: (searching) => set({ isSearching: searching }),
       replaceText: '',
       setReplaceText: (text) => set({ replaceText: text }),
+
+      // インアプリブラウザ
+      browserUrl: DEFAULT_BROWSER_URL,
+      setBrowserUrl: (url) => set({ browserUrl: url || DEFAULT_BROWSER_URL }),
+      openBrowserWithUrl: (url) =>
+        set((state) => ({
+          browserUrl: url || DEFAULT_BROWSER_URL,
+          paneState: {
+            ...state.paneState,
+            activeSidebar: 'browser',
+            isBrowserVisible: true,
+          },
+        })),
       
       // 分析機能
       analysisEnabled: false,
@@ -649,6 +670,7 @@ export const useEditorStore = create<EditorStore>()(
           lastViewMode: state.lastViewMode,
           editorSettings: state.editorSettings,
           paneState: state.paneState,
+          browserUrl: state.browserUrl,
           searchSettings: state.searchSettings,
           analysisEnabled: state.analysisEnabled,
           chartSettings: state.chartSettings,
@@ -715,6 +737,9 @@ export const useEditorStore = create<EditorStore>()(
           if (!state.lastViewMode) {
             state.lastViewMode = 'editor';
           }
+          if (!state.browserUrl) {
+            state.browserUrl = DEFAULT_BROWSER_URL;
+          }
           if (!state.sqlNotebook) {
             state.sqlNotebook = {};
           } else {
@@ -747,6 +772,7 @@ export const useEditorStore = create<EditorStore>()(
             state.paneState = {
               activeSidebar: 'explorer',
               isExplorerVisible: true,
+              isBrowserVisible: false,
               isGisVisible: false,
               isEditorVisible: true,
               isPreviewVisible: true,
@@ -762,10 +788,14 @@ export const useEditorStore = create<EditorStore>()(
             if (typeof state.paneState.activeSidebar === 'undefined') {
               const inferredSidebar = state.paneState.isExplorerVisible
                 ? 'explorer'
+                : state.paneState.isBrowserVisible
+                  ? 'browser'
                 : state.paneState.isGisVisible
                   ? 'gis'
                 : state.paneState.isGitVisible
                   ? 'git'
+                : state.paneState.isHelpVisible
+                  ? 'help'
                   : null;
               state.paneState = { ...state.paneState, activeSidebar: inferredSidebar };
             }
@@ -774,6 +804,9 @@ export const useEditorStore = create<EditorStore>()(
             }
             if (typeof state.paneState.isGitVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isGitVisible: false };
+            }
+            if (typeof state.paneState.isBrowserVisible !== 'boolean') {
+              state.paneState = { ...state.paneState, isBrowserVisible: false };
             }
             if (typeof state.paneState.isHelpVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isHelpVisible: false };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,8 +83,9 @@ export interface EditorSettings {
 
 // パネル表示状態に関する型定義
 export interface PaneState {
-  activeSidebar: 'explorer' | 'gis' | 'git' | 'help' | null;
+  activeSidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help' | null;
   isExplorerVisible: boolean;
+  isBrowserVisible: boolean;
   isGisVisible: boolean;
   isEditorVisible: boolean;
   isPreviewVisible: boolean;
@@ -95,6 +96,7 @@ export interface PaneState {
   isHelpVisible: boolean;
   sidebarWidths: {
     explorer: number;
+    browser: number;
     gis: number;
     git: number;
     help: number;


### PR DESCRIPTION
## Summary
- add a cloud storage section in the explorer that opens Google Drive in the in-app browser
- persist the browser panel URL in the editor store so other components can request navigation
- remove the ChatGPT and Google Gemini header icons and refresh browser quick links

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e25c97394c832f876f53b6e4f034e6