### PR TITLE
Allow runtime configuration of Google Drive client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ DataLoom Studio は、ファイル管理・エディタ・プレビュー・デ�
 - `OPENAI_API_KEY` が設定されている場合はそちらが優先され、ダイアログからも状態を確認できます
 - 保存済みのキーは同ダイアログから削除・再読込が可能です
 
+## Google Drive 連携
+- エクスプローラ上で Google Drive のツリーを表示し、テキスト/表形式ファイルは直接タブで開けます（その他のファイルは Drive で開くリンクを提供）。
+- 利用には Google Identity Services の OAuth クライアント（アプリケーション種別: ウェブアプリケーション）を作成し、承認済みの JavaScript 生成元に本アプリの URL（例: `http://localhost:3000`）を登録する必要があります。
+- 発行されたクライアント ID（例: `1234567890-abcdefghijklmnop.apps.googleusercontent.com`）をエクスプローラ内の「Google OAuth クライアント ID」欄に入力するか、環境変数 `NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID` に設定すると連携が有効になります。
+- `npm run dev` を起動した状態でエクスプローラに表示される「Google Drive」セクションからサインインすると、`drive.readonly` スコープでアクセストークンを取得します。
+- トークンはメモリ上のみで扱われ、再読み込みまたはサインアウトで破棄されます。Electron 版でも同じ手順で利用できます。
+
  ## 主要機能（実装済み） — 完全網羅
  以下はソースコード（src/components, src/lib, src/store）をもとに整理した実装済み機能の完全一覧です。MyGPT に取り込む際は、このまま要点を納めてください。
 

--- a/src/components/browser/BrowserPanel.tsx
+++ b/src/components/browser/BrowserPanel.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IoReloadOutline, IoReturnDownForwardOutline } from 'react-icons/io5';
+import { DEFAULT_BROWSER_URL, useEditorStore } from '@/store/editorStore';
+
+const DEFAULT_URL = DEFAULT_BROWSER_URL;
+
+const QUICK_LINKS: { label: string; url: string }[] = [{ label: 'Google', url: DEFAULT_BROWSER_URL }];
+
+const normalizeUrl = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_URL;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+};
+
+const BLOCKED_HOSTNAMES = new Set<string>(['chatgpt.com', 'gemini.google.com']);
+
+const BLOCKED_HOST_MESSAGES: Record<string, string> = {
+  'chatgpt.com':
+    'ChatGPT は X-Frame-Options などのポリシーで外部サイトからの埋め込みを禁止しているため、このパネル内では表示できません。',
+  'gemini.google.com':
+    'Google Gemini は厳格な CSP (Content-Security-Policy) を設定しており、別サイトから iframe で読み込むことができません。',
+};
+
+const BrowserPanel: React.FC = () => {
+  const browserUrl = useEditorStore((state) => state.browserUrl);
+  const setBrowserUrl = useEditorStore((state) => state.setBrowserUrl);
+  const [urlInput, setUrlInput] = useState(browserUrl || DEFAULT_URL);
+  const [currentUrl, setCurrentUrl] = useState(browserUrl || DEFAULT_URL);
+  const [isLoading, setIsLoading] = useState(true);
+  const [iframeKey, setIframeKey] = useState(() => Date.now());
+
+  const hostLabel = useMemo(() => {
+    try {
+      const parsed = new URL(currentUrl);
+      return parsed.hostname;
+    } catch {
+      return currentUrl;
+    }
+  }, [currentUrl]);
+
+  const { isLikelyBlocked, blockedDescription } = useMemo(() => {
+    try {
+      const { hostname } = new URL(currentUrl);
+      if (!BLOCKED_HOSTNAMES.has(hostname)) {
+        return { isLikelyBlocked: false, blockedDescription: '' };
+      }
+
+      return {
+        isLikelyBlocked: true,
+        blockedDescription:
+          BLOCKED_HOST_MESSAGES[hostname] ??
+          'このサイトは埋め込み表示をサポートしていないため、直接アクセスする必要があります。',
+      };
+    } catch {
+      return { isLikelyBlocked: false, blockedDescription: '' };
+    }
+  }, [currentUrl]);
+
+  useEffect(() => {
+    const nextUrl = browserUrl || DEFAULT_URL;
+    setCurrentUrl(nextUrl);
+    setUrlInput(nextUrl);
+    setIsLoading(true);
+    setIframeKey(Date.now());
+  }, [browserUrl]);
+
+  const navigateTo = useCallback(
+    (nextUrl: string) => {
+      setBrowserUrl(nextUrl);
+    },
+    [setBrowserUrl],
+  );
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      navigateTo(normalizeUrl(urlInput));
+    },
+    [navigateTo, urlInput],
+  );
+
+  const handleQuickLink = useCallback(
+    (url: string) => {
+      navigateTo(url);
+    },
+    [navigateTo],
+  );
+
+  const handleReload = useCallback(() => {
+    setIframeKey(Date.now());
+    setIsLoading(true);
+  }, []);
+
+  useEffect(() => {
+    if (isLikelyBlocked) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+  }, [currentUrl, isLikelyBlocked]);
+
+  const handleOpenExternally = useCallback(() => {
+    if (!currentUrl) {
+      return;
+    }
+
+    window.open(currentUrl, '_blank', 'noopener,noreferrer');
+  }, [currentUrl]);
+
+  return (
+    <div className="flex h-full flex-col bg-gray-50 dark:bg-slate-950">
+      <div className="border-b border-gray-200 bg-white px-3 py-2 dark:border-gray-800 dark:bg-slate-900">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleReload}
+            className="flex h-9 w-9 items-center justify-center rounded border border-gray-300 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            title="再読み込み"
+            aria-label="再読み込み"
+          >
+            <IoReloadOutline size={18} />
+          </button>
+          <input
+            className="h-9 flex-1 rounded border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-slate-950 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400/40"
+            value={urlInput}
+            onChange={(event) => setUrlInput(event.target.value)}
+            placeholder="https://"
+            spellCheck={false}
+            aria-label="URL入力"
+          />
+          <button
+            type="submit"
+            className="flex h-9 items-center gap-1 rounded border border-blue-500 bg-blue-500 px-3 text-sm font-medium text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+          >
+            <IoReturnDownForwardOutline size={18} />
+            開く
+          </button>
+        </form>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {QUICK_LINKS.map((link) => (
+            <button
+              key={link.url}
+              type="button"
+              onClick={() => handleQuickLink(link.url)}
+              className="rounded-full border border-transparent bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700"
+            >
+              {link.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 border-b border-gray-200 px-3 py-2 text-xs text-gray-600 dark:border-gray-800 dark:text-gray-300">
+        <span className="font-medium">現在のサイト: {hostLabel}</span>
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          一部のサイト（ChatGPT や Google Gemini など）はセキュリティポリシーにより iframe での表示が禁止されています。その場合はヘッダーのショートカットまたは「新しいタブで開く」から直接アクセスしてください。
+        </span>
+      </div>
+      <div className="relative flex-1 overflow-hidden">
+        <iframe
+          key={iframeKey}
+          src={currentUrl}
+          title="ブラウザビュー"
+          className="h-full w-full border-0 bg-white dark:bg-slate-900"
+          onLoad={() => setIsLoading(false)}
+          allow="clipboard-read; clipboard-write; geolocation *; microphone *; camera *; autoplay *"
+        />
+        {isLikelyBlocked && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/90 px-4 text-center text-sm text-gray-700 dark:bg-slate-950/90 dark:text-gray-200">
+            <p className="font-medium">このサイトは埋め込み表示が制限されています。</p>
+            <p className="max-w-xs text-xs text-gray-500 dark:text-gray-400">
+              {blockedDescription ||
+                '安全性の理由から iframe 内で読み込めない場合があります。下のボタンからブラウザで開いてください。'}
+            </p>
+            <button
+              type="button"
+              onClick={handleOpenExternally}
+              className="rounded border border-blue-500 bg-blue-500 px-4 py-1.5 text-xs font-medium text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              新しいタブで開く
+            </button>
+          </div>
+        )}
+        {isLoading && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-slate-950/60">
+            <div className="rounded-full border border-gray-300 bg-white px-4 py-1 text-sm font-medium text-gray-700 shadow dark:border-gray-700 dark:bg-slate-900 dark:text-gray-200">
+              読み込み中...
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BrowserPanel;

--- a/src/components/explorer/FileExplorer.tsx
+++ b/src/components/explorer/FileExplorer.tsx
@@ -45,6 +45,7 @@ import InputDialog from '@/components/modals/InputDialog';
 import ConfirmDialog from '@/components/modals/ConfirmDialog';
 import MermaidTemplateDialog from '@/components/modals/MermaidTemplateDialog';
 import type { MermaidDiagramType } from '@/lib/mermaid/types';
+import GoogleDriveExplorer from './GoogleDriveExplorer';
 
 /**
  * FileExplorerコンポーネント
@@ -60,20 +61,20 @@ const FileExplorer = () => {
     rootDirHandle,
     rootFolderName,
     setRootDirHandle,
-    setRootFileTree, 
+    setRootFileTree,
     setRootFolderName,
     addTab,
     addTempTab,
     activeTabId,
     setActiveTabId,
-  updateTab,
+    updateTab,
     tabs,
     setContextMenuTarget,
     contextMenuTarget,
     multiFileAnalysisEnabled,
     selectedFiles,
     addSelectedFile,
-    removeSelectedFile
+    removeSelectedFile,
   } = useEditorStore();
   const setGitRootDirectory = useGitStore((state) => state.setRootDirectory);
   // Avoid returning an object literal from the selector which creates a new
@@ -183,7 +184,7 @@ const FileExplorer = () => {
       alert(`フォルダの選択中にエラーが発生しました: ${error instanceof Error ? error.message : '不明なエラー'}`);
     }
   };
-  
+
   // フォルダの展開状態を切り替え
   const toggleFolder = (path: string) => {
     const newExpandedFolders = new Set(expandedFolders);
@@ -799,6 +800,7 @@ const FileExplorer = () => {
       
       {/* ファイルツリー */}
       <div className="flex-1 overflow-auto">
+        <GoogleDriveExplorer />
         {rootFileTree ? (
           <div className="py-1 text-sm">
             {renderFileTree(rootFileTree)}

--- a/src/components/explorer/GoogleDriveExplorer.tsx
+++ b/src/components/explorer/GoogleDriveExplorer.tsx
@@ -1,0 +1,765 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IoChevronDown,
+  IoChevronForward,
+  IoCloudOutline,
+  IoDocumentOutline,
+  IoInformationCircleOutline,
+  IoLinkOutline,
+  IoLogInOutline,
+  IoLogOutOutline,
+  IoReloadOutline,
+  IoSaveOutline,
+  IoTrashOutline,
+  IoWarningOutline,
+} from 'react-icons/io5';
+import { useEditorStore } from '@/store/editorStore';
+import type { TabData } from '@/types';
+
+type GoogleDriveMime = string;
+
+interface DriveTreeItem {
+  id: string;
+  resourceId: string;
+  name: string;
+  mimeType: GoogleDriveMime;
+  isFolder: boolean;
+  isShortcut: boolean;
+  webViewLink?: string;
+  webContentLink?: string;
+}
+
+interface GoogleTokenResponse {
+  access_token: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+  error?: string;
+}
+
+interface GoogleTokenClientConfig {
+  client_id: string;
+  scope: string;
+  callback: (response: GoogleTokenResponse) => void;
+  prompt?: 'consent' | 'select_account' | 'none';
+}
+
+interface GoogleTokenClient {
+  callback: (response: GoogleTokenResponse) => void;
+  requestAccessToken: (options?: { prompt?: 'consent' | 'select_account' | 'none' }) => void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        oauth2?: {
+          initTokenClient: (config: GoogleTokenClientConfig) => GoogleTokenClient;
+          revoke: (accessToken: string, done: () => void) => void;
+        };
+      };
+    };
+  }
+}
+
+const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
+const DRIVE_API_ENDPOINT = 'https://www.googleapis.com/drive/v3/files';
+const GOOGLE_IDENTITY_SCRIPT = 'https://accounts.google.com/gsi/client';
+
+const SCRIPT_CACHE: Record<string, Promise<void>> = {};
+
+const loadScript = (src: string) => {
+  if (SCRIPT_CACHE[src]) {
+    return SCRIPT_CACHE[src];
+  }
+
+  SCRIPT_CACHE[src] = new Promise<void>((resolve, reject) => {
+    if (typeof document === 'undefined') {
+      reject(new Error('Document is not available'));
+      return;
+    }
+
+    if (document.querySelector(`script[src="${src}"]`)) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(script);
+  });
+
+  return SCRIPT_CACHE[src];
+};
+
+const SUPPORTED_MIME_AS_TEXT = new Map<GoogleDriveMime, { exportMime?: string; tabType: TabData['type']; description: string }>([
+  ['text/plain', { tabType: 'text', description: 'テキストとして開きます。' }],
+  ['text/markdown', { tabType: 'markdown', description: 'Markdown として開きます。' }],
+  ['application/json', { tabType: 'json', description: 'JSON として開きます。' }],
+  ['application/vnd.google-apps.document', {
+    exportMime: 'text/plain',
+    tabType: 'markdown',
+    description: 'Google ドキュメントをテキストに変換して開きます。',
+  }],
+  ['text/csv', { tabType: 'csv', description: 'CSV として開きます。' }],
+  ['text/tab-separated-values', { tabType: 'tsv', description: 'TSV として開きます。' }],
+  ['application/vnd.google-apps.spreadsheet', {
+    exportMime: 'text/csv',
+    tabType: 'csv',
+    description: 'Google スプレッドシートを CSV に変換して開きます。',
+  }],
+  ['application/vnd.google-apps.script', {
+    exportMime: 'application/vnd.google-apps.script+json',
+    tabType: 'json',
+    description: 'Apps Script プロジェクトを JSON として開きます。',
+  }],
+]);
+
+const SUPPORTED_MIME_AS_BLOB = new Map<GoogleDriveMime, { exportMime?: string; tabType: TabData['type']; description: string }>([
+  ['application/pdf', { tabType: 'pdf', description: 'PDF をプレビュー用に読み込みます。' }],
+]);
+
+const GoogleDriveExplorer: React.FC = () => {
+  const envClientId = process.env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID || '';
+  const storedClientId = useEditorStore((state) => state.googleDriveClientId);
+  const setGoogleDriveClientId = useEditorStore((state) => state.setGoogleDriveClientId);
+  const clientId = useMemo(() => {
+    const trimmedStored = storedClientId?.trim();
+    if (trimmedStored) {
+      return trimmedStored;
+    }
+    const trimmedEnv = envClientId.trim();
+    return trimmedEnv || '';
+  }, [envClientId, storedClientId]);
+  const addTab = useEditorStore((state) => state.addTab);
+  const updateTab = useEditorStore((state) => state.updateTab);
+  const setActiveTabId = useEditorStore((state) => state.setActiveTabId);
+
+  const [gisReady, setGisReady] = useState(false);
+  const [tokenClient, setTokenClient] = useState<GoogleTokenClient | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authInProgress, setAuthInProgress] = useState(false);
+
+  const [driveChildren, setDriveChildren] = useState<Record<string, DriveTreeItem[]>>({});
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  const [loadingFolders, setLoadingFolders] = useState<Set<string>>(new Set());
+  const [folderErrors, setFolderErrors] = useState<Record<string, string>>({});
+  const [previewingId, setPreviewingId] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [clientIdInput, setClientIdInput] = useState<string>(storedClientId || '');
+
+  const isSignedIn = Boolean(accessToken);
+  const isBrowser = typeof window !== 'undefined';
+  const appOrigin = isBrowser ? window.location.origin : 'http://localhost:3000';
+  const isUsingEnvClientId = !storedClientId?.trim() && Boolean(envClientId.trim());
+
+  useEffect(() => {
+    setClientIdInput(storedClientId || '');
+  }, [storedClientId]);
+
+  useEffect(() => {
+    setAccessToken(null);
+    setTokenClient(null);
+    setAuthError(null);
+    setAuthInProgress(false);
+    setDriveChildren({});
+    setExpandedFolders(new Set<string>());
+    setLoadingFolders(new Set<string>());
+    setFolderErrors({});
+    setPreviewingId(null);
+    setPreviewError(null);
+  }, [clientId]);
+
+  useEffect(() => {
+    if (!isBrowser || !clientId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    loadScript(GOOGLE_IDENTITY_SCRIPT)
+      .then(() => {
+        if (cancelled) return;
+        setGisReady(true);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setAuthError(error instanceof Error ? error.message : String(error));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, isBrowser]);
+
+  useEffect(() => {
+    if (!gisReady || !clientId || !isBrowser) {
+      return;
+    }
+
+    const oauth2 = window.google?.accounts?.oauth2;
+    if (!oauth2) {
+      setAuthError('Google Identity Services の初期化に失敗しました。');
+      return;
+    }
+
+    try {
+      const client = oauth2.initTokenClient({
+        client_id: clientId,
+        scope: DRIVE_SCOPE,
+        callback: () => {
+          // callback は handleAuthorize 内で差し替える
+        },
+      });
+      setTokenClient(client);
+    } catch (error) {
+      setAuthError(error instanceof Error ? error.message : String(error));
+    }
+  }, [clientId, gisReady, isBrowser]);
+
+  const handleClientIdSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setGoogleDriveClientId(clientIdInput.trim());
+    },
+    [clientIdInput, setGoogleDriveClientId],
+  );
+
+  const handleClientIdClear = useCallback(() => {
+    setGoogleDriveClientId('');
+    setClientIdInput('');
+  }, [setGoogleDriveClientId]);
+
+  const hasClientIdChanges = useMemo(() => {
+    return clientIdInput.trim() !== (storedClientId || '').trim();
+  }, [clientIdInput, storedClientId]);
+
+  const normalizeDriveItem = useCallback((item: any): DriveTreeItem => {
+    const isShortcut = item.mimeType === 'application/vnd.google-apps.shortcut';
+    const targetId: string | undefined = isShortcut ? item.shortcutDetails?.targetId : undefined;
+    const targetMime: GoogleDriveMime | undefined = isShortcut ? item.shortcutDetails?.targetMimeType : undefined;
+    const effectiveId = targetId || item.id;
+    const effectiveMime = targetMime || item.mimeType;
+
+    return {
+      id: effectiveId,
+      resourceId: item.id,
+      name: item.name,
+      mimeType: effectiveMime,
+      isFolder: effectiveMime === 'application/vnd.google-apps.folder',
+      isShortcut,
+      webViewLink: item.webViewLink,
+      webContentLink: item.webContentLink,
+    };
+  }, []);
+
+  const fetchFolder = useCallback(
+    async (folderId: string) => {
+      if (!accessToken) {
+        return;
+      }
+
+      setLoadingFolders((prev) => new Set(prev).add(folderId));
+      setFolderErrors((prev) => {
+        const next = { ...prev };
+        delete next[folderId];
+        return next;
+      });
+
+      try {
+        const collected: DriveTreeItem[] = [];
+        let pageToken: string | undefined;
+
+        do {
+          const params = new URLSearchParams({
+            q: `'${folderId}' in parents and trashed = false`,
+            fields:
+              'nextPageToken, files(id, name, mimeType, webViewLink, webContentLink, shortcutDetails(targetId, targetMimeType))',
+            orderBy: 'folder,name',
+            pageSize: '100',
+            includeItemsFromAllDrives: 'false',
+            supportsAllDrives: 'false',
+          });
+          if (pageToken) {
+            params.set('pageToken', pageToken);
+          }
+
+          const response = await fetch(`${DRIVE_API_ENDPOINT}?${params.toString()}`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          });
+
+          if (!response.ok) {
+            const message = await response.text();
+            let parsed = message;
+            try {
+              const json = JSON.parse(message);
+              parsed = json.error?.message || message;
+            } catch {
+              // ignore
+            }
+            throw new Error(parsed);
+          }
+
+          const data = await response.json();
+          const files: any[] = data.files ?? [];
+          collected.push(...files.map((file) => normalizeDriveItem(file)));
+          pageToken = data.nextPageToken || undefined;
+        } while (pageToken);
+
+        collected.sort((a, b) => {
+          if (a.isFolder && !b.isFolder) return -1;
+          if (!a.isFolder && b.isFolder) return 1;
+          return a.name.localeCompare(b.name, 'ja');
+        });
+
+        setDriveChildren((prev) => ({ ...prev, [folderId]: collected }));
+      } catch (error) {
+        setFolderErrors((prev) => ({
+          ...prev,
+          [folderId]: error instanceof Error ? error.message : 'Google Drive からの読み込みに失敗しました。',
+        }));
+      } finally {
+        setLoadingFolders((prev) => {
+          const next = new Set(prev);
+          next.delete(folderId);
+          return next;
+        });
+      }
+    },
+    [accessToken, normalizeDriveItem],
+  );
+
+  useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+    fetchFolder('root');
+  }, [accessToken, fetchFolder]);
+
+  useEffect(() => {
+    if (!driveChildren.root || driveChildren.root.length === 0) {
+      return;
+    }
+    setExpandedFolders((prev) => {
+      if (prev.size > 0) {
+        return prev;
+      }
+      return new Set<string>(['root']);
+    });
+  }, [driveChildren.root]);
+
+  const handleAuthorize = useCallback(() => {
+    if (!tokenClient) {
+      setAuthError('Google Drive 認証クライアントが初期化されていません。');
+      return;
+    }
+
+    setAuthError(null);
+    setAuthInProgress(true);
+    tokenClient.callback = (response) => {
+      setAuthInProgress(false);
+      if (response.error) {
+        setAuthError(response.error);
+        return;
+      }
+      setAccessToken(response.access_token);
+    };
+    try {
+      tokenClient.requestAccessToken({ prompt: 'consent' });
+    } catch (error) {
+      setAuthInProgress(false);
+      setAuthError(error instanceof Error ? error.message : String(error));
+    }
+  }, [tokenClient]);
+
+  const handleSignOut = useCallback(() => {
+    if (!accessToken) {
+      return;
+    }
+
+    const revoke = window.google?.accounts?.oauth2?.revoke;
+    const clearState = () => {
+      setAccessToken(null);
+      setDriveChildren({});
+      setExpandedFolders(new Set());
+      setFolderErrors({});
+    };
+
+    if (revoke) {
+      revoke(accessToken, clearState);
+    } else {
+      clearState();
+    }
+  }, [accessToken]);
+
+  const handleToggleFolder = useCallback(
+    (item: DriveTreeItem) => {
+      setExpandedFolders((prev) => {
+        const next = new Set(prev);
+        const key = item.resourceId;
+        if (next.has(key)) {
+          next.delete(key);
+        } else {
+          next.add(key);
+          if (!driveChildren[item.id]) {
+            fetchFolder(item.id);
+          }
+        }
+        return next;
+      });
+    },
+    [driveChildren, fetchFolder],
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (!accessToken) {
+      return;
+    }
+    setDriveChildren({});
+    setExpandedFolders(new Set());
+    setFolderErrors({});
+    fetchFolder('root');
+  }, [accessToken, fetchFolder]);
+
+  const openInDrive = useCallback((item: DriveTreeItem) => {
+    const url = item.webViewLink || `https://drive.google.com/file/d/${item.id}/view`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const handlePreview = useCallback(
+    async (item: DriveTreeItem) => {
+      if (item.isFolder) {
+        handleToggleFolder(item);
+        return;
+      }
+
+      if (!accessToken) {
+        setPreviewError('Google Drive にサインインしてください。');
+        return;
+      }
+
+      const textConfig = SUPPORTED_MIME_AS_TEXT.get(item.mimeType);
+      const blobConfig = SUPPORTED_MIME_AS_BLOB.get(item.mimeType);
+
+      if (!textConfig && !blobConfig) {
+        setPreviewError('このファイルタイプはまだエクスプローラ内でプレビューできません。Drive で開いてください。');
+        return;
+      }
+
+      setPreviewError(null);
+      setPreviewingId(item.resourceId);
+
+      try {
+        const exportConfig = textConfig?.exportMime || blobConfig?.exportMime;
+        const url = exportConfig
+          ? `${DRIVE_API_ENDPOINT}/${encodeURIComponent(item.id)}/export?mimeType=${encodeURIComponent(exportConfig)}`
+          : `${DRIVE_API_ENDPOINT}/${encodeURIComponent(item.id)}?alt=media`;
+
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) {
+          const message = await response.text();
+          let parsed = message;
+          try {
+            const json = JSON.parse(message);
+            parsed = json.error?.message || message;
+          } catch {
+            // ignore JSON parse errors
+          }
+          throw new Error(parsed);
+        }
+
+        let content: string;
+        let tabType: TabData['type'];
+
+        if (textConfig) {
+          content = await response.text();
+          tabType = textConfig.tabType;
+        } else {
+          const blob = await response.blob();
+          content = URL.createObjectURL(blob);
+          tabType = blobConfig?.tabType || 'text';
+        }
+
+        const tabId = `gdrive:${item.id}`;
+        const tabName = `${item.name} (Drive)`;
+        const existingTab = useEditorStore.getState().tabs.get(tabId);
+        if (existingTab) {
+          updateTab(tabId, {
+            content,
+            originalContent: content,
+            isDirty: false,
+            type: tabType,
+            isReadOnly: true,
+          });
+        } else {
+          const tabData: TabData = {
+            id: tabId,
+            name: tabName,
+            content,
+            originalContent: content,
+            isDirty: false,
+            type: tabType,
+            isReadOnly: true,
+          };
+          addTab(tabData);
+        }
+        setActiveTabId(tabId);
+      } catch (error) {
+        setPreviewError(error instanceof Error ? error.message : 'ファイルの読み込みに失敗しました。');
+      } finally {
+        setPreviewingId(null);
+      }
+    },
+    [accessToken, addTab, handleToggleFolder, setActiveTabId, updateTab],
+  );
+
+  const renderChildren = (folderId: string, level: number): React.ReactNode => {
+      const items = driveChildren[folderId];
+      const isLoading = loadingFolders.has(folderId);
+      const errorMessage = folderErrors[folderId];
+
+      if (isLoading && !items) {
+        return (
+          <div className="flex items-center gap-2 py-2 text-xs text-gray-500" style={{ paddingLeft: `${level * 12 + 16}px` }}>
+            <IoReloadOutline className="animate-spin" size={14} /> 読み込み中...
+          </div>
+        );
+      }
+
+      if (errorMessage && !items) {
+        return (
+          <div className="flex items-start gap-2 py-2 text-xs text-red-600" style={{ paddingLeft: `${level * 12 + 16}px` }}>
+            <IoWarningOutline size={14} className="mt-0.5" />
+            <span className="leading-relaxed">{errorMessage}</span>
+          </div>
+        );
+      }
+
+      if (!items || items.length === 0) {
+        return (
+          <div className="py-2 text-xs text-gray-500" style={{ paddingLeft: `${level * 12 + 16}px` }}>
+            空のフォルダです。
+          </div>
+        );
+      }
+
+      return items.map((item) => {
+        const treeKey = item.resourceId;
+        const paddingLeft = `${level * 12 + 4}px`;
+
+        if (item.isFolder) {
+          const isExpanded = expandedFolders.has(treeKey);
+          const childLoading = loadingFolders.has(item.id);
+          return (
+            <div key={treeKey}>
+              <div
+                className="flex items-center py-1 pl-1 pr-2 text-sm hover:bg-gray-200 dark:hover:bg-gray-700"
+                style={{ paddingLeft }}
+                onClick={() => handleToggleFolder(item)}
+                role="button"
+                tabIndex={0}
+              >
+                <span className="mr-1 text-gray-500">
+                  {isExpanded ? <IoChevronDown size={14} /> : <IoChevronForward size={14} />}
+                </span>
+                <IoCloudOutline className="mr-2 text-blue-500" size={16} />
+                <span className="truncate text-sm text-gray-800 dark:text-gray-100">{item.name}</span>
+                {item.isShortcut && (
+                  <span className="ml-2 rounded bg-gray-200 px-2 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                    ショートカット
+                  </span>
+                )}
+                {childLoading && <IoReloadOutline size={14} className="ml-auto animate-spin text-gray-500" />}
+              </div>
+              {isExpanded && <div>{renderChildren(item.id, level + 1)}</div>}
+            </div>
+          );
+        }
+
+        const isLoadingPreview = previewingId === treeKey;
+
+        return (
+          <div
+            key={treeKey}
+            className="flex items-center py-1 pl-1 pr-2 text-sm hover:bg-blue-50 dark:hover:bg-slate-800"
+            style={{ paddingLeft }}
+            onClick={() => handlePreview(item)}
+            role="button"
+            tabIndex={0}
+          >
+            <IoDocumentOutline className="mr-2 text-gray-500" size={16} />
+            <span className="truncate text-sm text-gray-800 dark:text-gray-100">{item.name}</span>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                openInDrive(item);
+              }}
+              className="ml-auto flex items-center gap-1 rounded border border-gray-300 px-2 py-0.5 text-[11px] text-gray-600 transition hover:bg-gray-200 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              <IoLinkOutline size={12} />
+              Drive
+            </button>
+            {isLoadingPreview && <IoReloadOutline size={14} className="ml-2 animate-spin text-blue-500" />}
+          </div>
+        );
+      });
+    };
+
+  let rootSection: React.ReactNode = null;
+  if (isSignedIn) {
+    rootSection = (
+      <div className="py-2 text-sm">
+        <div
+          className="flex items-center py-1 pl-1 pr-2 text-sm hover:bg-gray-200 dark:hover:bg-gray-700"
+          onClick={() =>
+            setExpandedFolders((prev) => {
+              const next = new Set(prev);
+              if (next.has('root')) {
+                next.delete('root');
+              } else {
+                next.add('root');
+                if (!driveChildren.root) {
+                  fetchFolder('root');
+                }
+              }
+              return next;
+            })
+          }
+          role="button"
+          tabIndex={0}
+        >
+          <span className="mr-1 text-gray-500">
+            {expandedFolders.has('root') ? <IoChevronDown size={14} /> : <IoChevronForward size={14} />}
+          </span>
+          <IoCloudOutline className="mr-2 text-blue-600" size={16} />
+          <span className="text-sm font-medium text-gray-800 dark:text-gray-100">マイドライブ</span>
+          {loadingFolders.has('root') && <IoReloadOutline size={14} className="ml-auto animate-spin text-gray-500" />}
+        </div>
+        {expandedFolders.has('root') && <div>{renderChildren('root', 1)}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-b border-gray-300 bg-white px-3 py-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <IoCloudOutline className="text-blue-500" size={18} />
+          <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">Google Drive</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {isSignedIn ? (
+            <>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="flex items-center gap-1 rounded border border-blue-500 px-2 py-1 text-[11px] font-semibold text-blue-600 transition hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:border-blue-400 dark:text-blue-200 dark:hover:bg-blue-500/20"
+              >
+                <IoReloadOutline size={12} />
+                再同期
+              </button>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="flex items-center gap-1 rounded border border-gray-400 px-2 py-1 text-[11px] font-semibold text-gray-600 transition hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                <IoLogOutOutline size={12} />
+                サインアウト
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={handleAuthorize}
+              disabled={!clientId || authInProgress}
+              className="flex items-center gap-1 rounded border border-blue-500 bg-blue-500 px-3 py-1 text-[11px] font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              <IoLogInOutline size={12} />
+              Google でサインイン
+            </button>
+          )}
+        </div>
+      </div>
+      <form className="mt-3 space-y-2" onSubmit={handleClientIdSubmit}>
+        <label className="flex items-center gap-2 text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+          <IoInformationCircleOutline size={14} className="text-blue-500" />
+          Google OAuth クライアント ID
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            value={clientIdInput}
+            onChange={(event) => setClientIdInput(event.target.value)}
+            placeholder="例: 1234567890-abcdefghijklmnop.apps.googleusercontent.com"
+            className="flex-1 rounded border border-gray-300 px-2 py-1 text-[11px] text-gray-800 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-blue-300"
+            spellCheck={false}
+          />
+          <button
+            type="submit"
+            disabled={!clientIdInput.trim() || !hasClientIdChanges}
+            className="flex items-center gap-1 rounded border border-blue-500 bg-blue-500 px-2 py-1 text-[11px] font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-blue-400 dark:bg-blue-500 dark:hover:bg-blue-400"
+          >
+            <IoSaveOutline size={12} />
+            保存
+          </button>
+          <button
+            type="button"
+            onClick={handleClientIdClear}
+            disabled={!storedClientId}
+            className="flex items-center gap-1 rounded border border-gray-400 px-2 py-1 text-[11px] font-semibold text-gray-600 transition hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            <IoTrashOutline size={12} />
+            クリア
+          </button>
+        </div>
+        <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-[11px] leading-relaxed text-blue-700 dark:border-blue-500/60 dark:bg-blue-500/10 dark:text-blue-100">
+          <p>
+            Google Cloud Console で「OAuth 2.0 クライアント ID」を「ウェブアプリケーション」タイプとして作成し、承認済みの JavaScript 生成元に
+            <code className="mx-1 rounded bg-white/80 px-1 py-0.5 text-[10px] font-mono dark:bg-gray-900/60">{appOrigin}</code>
+            を追加してください。
+          </p>
+          <p className="mt-1">
+            発行されたクライアント ID を上記フィールド、または環境変数
+            <code className="mx-1 rounded bg-white/80 px-1 py-0.5 text-[10px] font-mono dark:bg-gray-900/60">NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID</code>
+            に設定すると、Google Drive 連携を利用できます。
+          </p>
+          {isUsingEnvClientId && (
+            <p className="mt-1 text-[10px] text-blue-600 dark:text-blue-200">
+              現在は環境変数に設定されたクライアント ID が使用されています。別の ID を利用したい場合は上記に入力して保存してください。
+            </p>
+          )}
+        </div>
+      </form>
+      <p className="mt-2 leading-relaxed">
+        Google Drive 上のファイルとフォルダをローカルフォルダと同じようにブラウズできます。テキスト系ファイルはタブで開き、その他のファイルは Drive で直接表示してください。
+      </p>
+      {!clientId && (
+        <p className="mt-3 rounded border border-yellow-400 bg-yellow-50 px-3 py-2 text-[11px] font-medium text-yellow-700 dark:border-yellow-500 dark:bg-yellow-500/10 dark:text-yellow-200">
+          Google OAuth クライアント ID が未設定のため、サインインボタンは無効化されています。上のフィールドにクライアント ID を登録すると利用可能になります。
+        </p>
+      )}
+      {authError && (
+        <p className="mt-3 rounded border border-red-400 bg-red-50 px-3 py-2 text-[11px] font-medium text-red-600 dark:border-red-500 dark:bg-red-500/10 dark:text-red-200">
+          {authError}
+        </p>
+      )}
+      {previewError && (
+        <p className="mt-3 rounded border border-orange-400 bg-orange-50 px-3 py-2 text-[11px] font-medium text-orange-600 dark:border-orange-500 dark:bg-orange-500/10 dark:text-orange-200">
+          {previewError}
+        </p>
+      )}
+      {rootSection}
+    </div>
+  );
+};
+
+export default GoogleDriveExplorer;

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -3,13 +3,14 @@
 import React from 'react';
 import {
   IoFolderOpenOutline,
+  IoBrowsersOutline,
   IoGlobeOutline,
   IoGitBranchOutline,
   IoChatbubblesOutline,
   IoGitMergeOutline,
 } from 'react-icons/io5';
 
-type ActivityItem = 'explorer' | 'gis' | 'git' | 'help';
+type ActivityItem = 'explorer' | 'browser' | 'gis' | 'git' | 'help';
 
 interface ActivityBarProps {
   activeItem: ActivityItem | null;
@@ -43,6 +44,15 @@ const ActivityBar: React.FC<ActivityBarProps> = ({
         aria-pressed={activeItem === 'explorer'}
       >
         <IoFolderOpenOutline size={20} />
+      </button>
+      <button
+        type="button"
+        className={`${baseButton} mt-2 ${activeItem === 'browser' ? activeClass : inactiveClass}`}
+        onClick={() => onSelect('browser')}
+        title="ブラウザ"
+        aria-pressed={activeItem === 'browser'}
+      >
+        <IoBrowsersOutline size={20} />
       </button>
       {multiFileAnalysisAvailable && (
         <button

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -12,6 +12,7 @@ import {
   IoDownloadOutline,
   IoKeyOutline,
   IoHelpCircleOutline,
+  IoBrowsersOutline,
 } from 'react-icons/io5';
 
 interface MainHeaderProps {
@@ -23,6 +24,8 @@ interface MainHeaderProps {
   onToggleTheme: () => void;
   onNewFile: () => void;
   onToggleSearch: () => void;
+  onToggleBrowser: () => void;
+  isBrowserPaneVisible: boolean;
   multiFileAnalysisEnabled: boolean;
   onToggleMultiFileAnalysis: () => void;
   selectedFileCount: number;
@@ -44,6 +47,8 @@ const MainHeader: React.FC<MainHeaderProps> = ({
   onToggleTheme,
   onNewFile,
   onToggleSearch,
+  onToggleBrowser,
+  isBrowserPaneVisible,
   multiFileAnalysisEnabled,
   onToggleMultiFileAnalysis,
   selectedFileCount,
@@ -115,6 +120,16 @@ const MainHeader: React.FC<MainHeaderProps> = ({
         aria-label="Toggle Search"
       >
         <IoSearch size={20} />
+      </button>
+      <button
+        className={`p-1 rounded ml-2 ${
+          isBrowserPaneVisible ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+        }`}
+        onClick={onToggleBrowser}
+        aria-label="Toggle Browser Panel"
+        title={`ブラウザパネル ${isBrowserPaneVisible ? '表示中' : '非表示'}`}
+      >
+        <IoBrowsersOutline size={20} />
       </button>
       <button
         className="p-1 rounded hover:bg-gray-200 ml-2 dark:hover:bg-gray-800"

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -102,6 +102,7 @@ const MainLayoutContent: React.FC = () => {
     (pane: keyof typeof paneState) => {
       if (
         pane === 'isExplorerVisible' ||
+        pane === 'isBrowserVisible' ||
         pane === 'isGisVisible' ||
         pane === 'isGitVisible' ||
         pane === 'isHelpVisible' ||
@@ -119,6 +120,19 @@ const MainLayoutContent: React.FC = () => {
     updatePaneState({
       activeSidebar: isActive ? null : 'explorer',
       isExplorerVisible: !isActive,
+      isBrowserVisible: false,
+      isGisVisible: false,
+      isGitVisible: false,
+      isHelpVisible: false,
+    });
+  }, [paneState.activeSidebar, updatePaneState]);
+
+  const handleToggleBrowserPane = useCallback(() => {
+    const isActive = paneState.activeSidebar === 'browser';
+    updatePaneState({
+      activeSidebar: isActive ? null : 'browser',
+      isBrowserVisible: !isActive,
+      isExplorerVisible: false,
       isGisVisible: false,
       isGitVisible: false,
       isHelpVisible: false,
@@ -132,6 +146,7 @@ const MainLayoutContent: React.FC = () => {
       isGitVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isHelpVisible: false,
     });
   }, [paneState.activeSidebar, updatePaneState]);
@@ -146,6 +161,7 @@ const MainLayoutContent: React.FC = () => {
       isHelpVisible: !isActive,
       isExplorerVisible: false,
       isGisVisible: false,
+      isBrowserVisible: false,
       isGitVisible: false,
     });
   }, [aiFeaturesEnabled, paneState.activeSidebar, updatePaneState]);
@@ -515,6 +531,8 @@ const MainLayoutContent: React.FC = () => {
         onToggleTheme={handleToggleTheme}
         onNewFile={() => setShowNewFileDialog(true)}
         onToggleSearch={() => togglePane('isSearchVisible')}
+        onToggleBrowser={handleToggleBrowserPane}
+        isBrowserPaneVisible={paneState.isBrowserVisible}
         multiFileAnalysisEnabled={multiFileAnalysisEnabled}
         onToggleMultiFileAnalysis={handleToggleMultiFile}
         selectedFileCount={selectedFiles.size}

--- a/src/components/layout/Workspace.tsx
+++ b/src/components/layout/Workspace.tsx
@@ -22,6 +22,7 @@ import GitCommitDiffView from '@/components/git/GitCommitDiffView';
 import HelpSidebar from '@/components/help/HelpSidebar';
 import ResizableSidebar from '@/components/layout/ResizableSidebar';
 import { DEFAULT_SIDEBAR_WIDTHS } from '@/constants/layout';
+import BrowserPanel from '@/components/browser/BrowserPanel';
 
 interface WorkspaceProps {
   paneState: PaneState;
@@ -51,6 +52,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
   const [isScrollSyncEnabled, setIsScrollSyncEnabled] = useState(false);
   const [sidebarWidths, setSidebarWidths] = useState({
     explorer: paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer,
+    browser: paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser,
     gis: paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis,
     git: paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git,
     help: paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help,
@@ -59,6 +61,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
 
   useEffect(() => {
     const nextExplorer = paneState.sidebarWidths?.explorer ?? DEFAULT_SIDEBAR_WIDTHS.explorer;
+    const nextBrowser = paneState.sidebarWidths?.browser ?? DEFAULT_SIDEBAR_WIDTHS.browser;
     const nextGis = paneState.sidebarWidths?.gis ?? DEFAULT_SIDEBAR_WIDTHS.gis;
     const nextGit = paneState.sidebarWidths?.git ?? DEFAULT_SIDEBAR_WIDTHS.git;
     const nextHelp = paneState.sidebarWidths?.help ?? DEFAULT_SIDEBAR_WIDTHS.help;
@@ -67,6 +70,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
     setSidebarWidths((previous) => {
       if (
         previous.explorer === nextExplorer &&
+        previous.browser === nextBrowser &&
         previous.gis === nextGis &&
         previous.git === nextGit &&
         previous.help === nextHelp &&
@@ -76,13 +80,21 @@ const Workspace: React.FC<WorkspaceProps> = ({
       }
       return {
         explorer: nextExplorer,
+        browser: nextBrowser,
         gis: nextGis,
         git: nextGit,
         help: nextHelp,
         search: nextSearch,
       };
     });
-  }, [paneState.sidebarWidths?.explorer, paneState.sidebarWidths?.gis, paneState.sidebarWidths?.git, paneState.sidebarWidths?.help, paneState.sidebarWidths?.search]);
+  }, [
+    paneState.sidebarWidths?.explorer,
+    paneState.sidebarWidths?.browser,
+    paneState.sidebarWidths?.gis,
+    paneState.sidebarWidths?.git,
+    paneState.sidebarWidths?.help,
+    paneState.sidebarWidths?.search,
+  ]);
 
   type SidebarKey = keyof typeof DEFAULT_SIDEBAR_WIDTHS;
 
@@ -151,6 +163,9 @@ const Workspace: React.FC<WorkspaceProps> = ({
     if (paneState.isExplorerVisible) {
       return 'explorer';
     }
+    if (paneState.isBrowserVisible) {
+      return 'browser';
+    }
     if (paneState.isGitVisible) {
       return 'git';
     }
@@ -161,15 +176,23 @@ const Workspace: React.FC<WorkspaceProps> = ({
       return 'help';
     }
     return null;
-  }, [paneState.activeSidebar, paneState.isExplorerVisible, paneState.isGitVisible, paneState.isGisVisible, paneState.isHelpVisible]);
+  }, [
+    paneState.activeSidebar,
+    paneState.isExplorerVisible,
+    paneState.isBrowserVisible,
+    paneState.isGitVisible,
+    paneState.isGisVisible,
+    paneState.isHelpVisible,
+  ]);
 
   const showExplorer = activeSidebar === 'explorer';
+  const showBrowserSidebar = activeSidebar === 'browser';
   const showGitSidebar = activeSidebar === 'git';
   const showGisSidebar = activeSidebar === 'gis';
   const showHelpSidebar = aiFeaturesEnabled && activeSidebar === 'help';
 
   const handleSidebarSelect = useCallback(
-    (sidebar: 'explorer' | 'gis' | 'git' | 'help') => {
+    (sidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help') => {
       if (sidebar === 'help' && !aiFeaturesEnabled) {
         return;
       }
@@ -177,6 +200,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
       updatePaneState({
         activeSidebar: isActive ? null : sidebar,
         isExplorerVisible: sidebar === 'explorer' ? !isActive : false,
+        isBrowserVisible: sidebar === 'browser' ? !isActive : false,
         isGisVisible: sidebar === 'gis' ? !isActive : false,
         isGitVisible: sidebar === 'git' ? !isActive : false,
         isHelpVisible: sidebar === 'help' ? !isActive : false,
@@ -439,6 +463,19 @@ const Workspace: React.FC<WorkspaceProps> = ({
           handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
         >
           <FileExplorer />
+        </ResizableSidebar>
+      )}
+      {showBrowserSidebar && (
+        <ResizableSidebar
+          width={sidebarWidths.browser}
+          minWidth={280}
+          maxWidth={720}
+          onResize={(width) => handleSidebarResize('browser', width)}
+          onResizeEnd={(width) => handleSidebarResizeEnd('browser', width)}
+          className="border-r border-gray-200 dark:border-gray-800 overflow-hidden"
+          handleClassName="hover:bg-gray-200/60 dark:hover:bg-gray-700/60"
+        >
+          <BrowserPanel />
         </ResizableSidebar>
       )}
       {showGisSidebar && (

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_SIDEBAR_WIDTHS = {
   explorer: 256,
+  browser: 420,
   gis: 288,
   git: 384,
   help: 384,

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -80,6 +80,14 @@ interface EditorStore {
   setIsSearching: (searching: boolean) => void;
   replaceText: string;
   setReplaceText: (text: string) => void;
+
+  // インアプリブラウザ
+  browserUrl: string;
+  setBrowserUrl: (url: string) => void;
+
+  // Google Drive 連携
+  googleDriveClientId: string;
+  setGoogleDriveClientId: (clientId: string) => void;
   
   // 分析機能
   analysisEnabled: boolean;
@@ -139,6 +147,8 @@ interface EditorStore {
   helpSettings: HelpSettings;
   updateHelpSettings: (updates: Partial<HelpSettings>) => void;
 }
+
+export const DEFAULT_BROWSER_URL = 'https://www.google.com/';
 
 export const useEditorStore = create<EditorStore>()(
   persist(
@@ -270,6 +280,7 @@ export const useEditorStore = create<EditorStore>()(
       paneState: {
         activeSidebar: 'explorer',
         isExplorerVisible: true,
+        isBrowserVisible: false,
         isGisVisible: false,
         isEditorVisible: true,
         isPreviewVisible: true,
@@ -304,6 +315,15 @@ export const useEditorStore = create<EditorStore>()(
       setIsSearching: (searching) => set({ isSearching: searching }),
       replaceText: '',
       setReplaceText: (text) => set({ replaceText: text }),
+
+      // インアプリブラウザ
+      browserUrl: DEFAULT_BROWSER_URL,
+      setBrowserUrl: (url) => set({ browserUrl: url || DEFAULT_BROWSER_URL }),
+
+      // Google Drive 連携
+      googleDriveClientId: process.env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID || '',
+      setGoogleDriveClientId: (clientId) =>
+        set({ googleDriveClientId: clientId.trim() }),
       
       // 分析機能
       analysisEnabled: false,
@@ -649,6 +669,8 @@ export const useEditorStore = create<EditorStore>()(
           lastViewMode: state.lastViewMode,
           editorSettings: state.editorSettings,
           paneState: state.paneState,
+          browserUrl: state.browserUrl,
+          googleDriveClientId: state.googleDriveClientId,
           searchSettings: state.searchSettings,
           analysisEnabled: state.analysisEnabled,
           chartSettings: state.chartSettings,
@@ -715,6 +737,12 @@ export const useEditorStore = create<EditorStore>()(
           if (!state.lastViewMode) {
             state.lastViewMode = 'editor';
           }
+          if (!state.browserUrl) {
+            state.browserUrl = DEFAULT_BROWSER_URL;
+          }
+          if (typeof state.googleDriveClientId !== 'string') {
+            state.googleDriveClientId = process.env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID || '';
+          }
           if (!state.sqlNotebook) {
             state.sqlNotebook = {};
           } else {
@@ -747,6 +775,7 @@ export const useEditorStore = create<EditorStore>()(
             state.paneState = {
               activeSidebar: 'explorer',
               isExplorerVisible: true,
+              isBrowserVisible: false,
               isGisVisible: false,
               isEditorVisible: true,
               isPreviewVisible: true,
@@ -762,10 +791,14 @@ export const useEditorStore = create<EditorStore>()(
             if (typeof state.paneState.activeSidebar === 'undefined') {
               const inferredSidebar = state.paneState.isExplorerVisible
                 ? 'explorer'
+                : state.paneState.isBrowserVisible
+                  ? 'browser'
                 : state.paneState.isGisVisible
                   ? 'gis'
                 : state.paneState.isGitVisible
                   ? 'git'
+                : state.paneState.isHelpVisible
+                  ? 'help'
                   : null;
               state.paneState = { ...state.paneState, activeSidebar: inferredSidebar };
             }
@@ -774,6 +807,9 @@ export const useEditorStore = create<EditorStore>()(
             }
             if (typeof state.paneState.isGitVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isGitVisible: false };
+            }
+            if (typeof state.paneState.isBrowserVisible !== 'boolean') {
+              state.paneState = { ...state.paneState, isBrowserVisible: false };
             }
             if (typeof state.paneState.isHelpVisible !== 'boolean') {
               state.paneState = { ...state.paneState, isHelpVisible: false };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,8 +83,9 @@ export interface EditorSettings {
 
 // パネル表示状態に関する型定義
 export interface PaneState {
-  activeSidebar: 'explorer' | 'gis' | 'git' | 'help' | null;
+  activeSidebar: 'explorer' | 'browser' | 'gis' | 'git' | 'help' | null;
   isExplorerVisible: boolean;
+  isBrowserVisible: boolean;
   isGisVisible: boolean;
   isEditorVisible: boolean;
   isPreviewVisible: boolean;
@@ -95,6 +96,7 @@ export interface PaneState {
   isHelpVisible: boolean;
   sidebarWidths: {
     explorer: number;
+    browser: number;
     gis: number;
     git: number;
     help: number;


### PR DESCRIPTION
## Summary
- add a persisted Google Drive client ID setting so the explorer can use values configured in the UI
- extend the Google Drive explorer with a setup form, inline guidance, and messaging when no client ID is available
- document how to create and supply the Google OAuth client ID via the new field or NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e25c97394c832f876f53b6e4f034e6