### PR TITLE
Add zoomable charts and word cloud filtering in analysis mode

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,6 +178,7 @@ export interface ChartDesignerSettings {
   pieHole: number;
   sunburstHole: number;
   collapsed: boolean;
+  wordCloudLimit?: number;
 }
 
 export interface AnalysisDataset {


### PR DESCRIPTION
## Summary
- enable persistent chart settings and larger, zoomable chart areas in the analysis panel
- add a dropdown to limit word cloud output to the most frequent terms and reuse saved selections
- extend chart designer settings with a wordCloudLimit option for downstream consumers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e37cc4c6a4832f808b9f3e39ad7c84