### PR TITLE
Add table display mode toggle to analysis results

### DIFF
--- a/src/components/analysis/DataAnalysis.tsx
+++ b/src/components/analysis/DataAnalysis.tsx
@@ -2777,6 +2777,8 @@ const DataAnalysis: React.FC<DataAnalysisProps> = ({ tabId }) => {
         chartTitle="クエリ結果でチャート作成"
         tableViewMode={queryTableViewMode}
         onTableViewModeChange={setQueryTableViewMode}
+        dataDisplayMode={editorSettings.dataDisplayMode}
+        onToggleDataDisplayMode={toggleDisplayMode}
       />
     );
   };

--- a/src/components/analysis/MultiFileAnalysis.tsx
+++ b/src/components/analysis/MultiFileAnalysis.tsx
@@ -1238,6 +1238,8 @@ const MultiFileAnalysis: React.FC<MultiFileAnalysisProps> = ({ onClose }) => {
                     initialView={cellView}
                     activeView={cellView}
                     onViewChange={(view) => setNotebookCellViews(prev => ({ ...prev, [cell.id]: view }))}
+                    dataDisplayMode={editorSettings.dataDisplayMode}
+                    onToggleDataDisplayMode={toggleDisplayMode}
                   />
                 ) : (
                   <div className="border border-gray-200 rounded p-4 text-sm text-gray-500">
@@ -1277,6 +1279,8 @@ const MultiFileAnalysis: React.FC<MultiFileAnalysisProps> = ({ onClose }) => {
         onEditedRowsChange={setEditedQueryResult}
         editingRows={editedQueryResult || dataToUse}
         chartTitle="クエリ結果でチャート作成"
+        dataDisplayMode={editorSettings.dataDisplayMode}
+        onToggleDataDisplayMode={toggleDisplayMode}
       />
     );
   };

--- a/src/components/analysis/ResultChartPanel.tsx
+++ b/src/components/analysis/ResultChartPanel.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ResultChartBuilder from './ResultChartBuilder';
 import QueryResultTable from './QueryResultTable';
 import EditableQueryResultTable from './EditableQueryResultTable';
-import { IoBarChartOutline, IoCodeSlash } from 'react-icons/io5';
+import { IoBarChartOutline, IoCodeSlash, IoLayersOutline } from 'react-icons/io5';
 import type { ChartDesignerSettings } from '@/types';
 
 interface ResultChartPanelProps {
@@ -22,6 +22,8 @@ interface ResultChartPanelProps {
   onViewChange?: (view: 'table' | 'chart') => void;
   tableViewMode?: 'react-table' | 'spread';
   onTableViewModeChange?: (mode: 'react-table' | 'spread') => void;
+  dataDisplayMode?: 'flat' | 'nested';
+  onToggleDataDisplayMode?: () => void;
 }
 
 const ResultChartPanel: React.FC<ResultChartPanelProps> = ({
@@ -39,6 +41,8 @@ const ResultChartPanel: React.FC<ResultChartPanelProps> = ({
   onViewChange,
   tableViewMode,
   onTableViewModeChange,
+  dataDisplayMode,
+  onToggleDataDisplayMode,
 }) => {
   const [internalView, setInternalView] = useState<'table' | 'chart'>(initialView);
   const [persistedChartSettings, setPersistedChartSettings] = useState<ChartDesignerSettings | undefined>(undefined);
@@ -128,6 +132,16 @@ const ResultChartPanel: React.FC<ResultChartPanelProps> = ({
               >
                 SpreadJS
               </button>
+              {onToggleDataDisplayMode && dataDisplayMode && (
+                <button
+                  className="inline-flex items-center px-2.5 py-1.5 text-xs rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  onClick={onToggleDataDisplayMode}
+                  title={dataDisplayMode === 'flat' ? '階層表示に切替' : 'フラット表示に切替'}
+                >
+                  <IoLayersOutline className="mr-1" size={14} />
+                  {dataDisplayMode === 'flat' ? '階層表示' : 'フラット表示'}
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- expose the flat/nested display toggle within ResultChartPanel when viewing tables
- pass analysis view display mode state through DataAnalysis and MultiFileAnalysis so query tables can switch modes from the tab header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5e2d404f8832fa140b6f94bcd5bbc