### PR TITLE
Improve folder selection UX and git author configuration

### DIFF
--- a/src/components/explorer/FileExplorer.tsx
+++ b/src/components/explorer/FileExplorer.tsx
@@ -216,18 +216,18 @@ const FileExplorer = () => {
       // @ts-ignore - File System Access API は実験的
       let dirHandle: FileSystemDirectoryHandle;
       try {
-        dirHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
+        dirHandle = await window.showDirectoryPicker();
       } catch (pickerError) {
         if (pickerError instanceof Error && pickerError.name === 'AbortError') {
           throw pickerError;
         }
-        if (pickerError instanceof TypeError) {
-          // 一部環境では mode オプションが未対応のためフォールバック
-          // @ts-ignore - File System Access API は実験的
-          dirHandle = await window.showDirectoryPicker();
-        } else {
-          throw pickerError;
-        }
+        throw pickerError;
+      }
+
+      const hasWritePermission = await ensureHandlePermission(dirHandle, 'readwrite');
+      if (!hasWritePermission) {
+        alert('フォルダへのアクセス権限が許可されませんでした。権限を付与してから再度お試しください。');
+        return;
       }
       setRootDirHandle(dirHandle);
       await setGitRootDirectory(dirHandle);


### PR DESCRIPTION
## Summary
- prevent duplicate folder selection prompts by using a single directory picker and explicit permission checks
- add an editor toolbar action to reload the active file from disk, reusing handles and guarding unsaved edits
- persist git author information and require it for commit/pull operations, passing the values to git pull to avoid author errors

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691185c94608832fa94a1859c1d71106)